### PR TITLE
Allow compound extensions (.tar.gz, .tar.xz, ...)

### DIFF
--- a/common/tasks_code_boxes.py
+++ b/common/tasks_code_boxes.py
@@ -108,8 +108,7 @@ class FileBox(BasicBox):
             return False
 
         try:
-            _, ext = os.path.splitext(taskInput[self.get_complete_id()]["filename"])
-            if ext not in self._allowed_exts:
+            if not taskInput[self.get_complete_id()]["filename"].endswith(tuple(self._allowed_exts)):
                 return False
 
             if sys.getsizeof(taskInput[self.get_complete_id()]["value"]) > self._max_size:


### PR DESCRIPTION
This fix is not complete, as we should also change https://github.com/UCL-INGI/INGInious/blob/master/frontend/pages/admin_course.py#L364 to generate the correct filename in the downloaded archive.

Basically, we want to take the longuest extension in the allowed extensions.
