### PR TITLE
Patch lti grading methods

### DIFF
--- a/inginious/backend/agent/simple_agent.py
+++ b/inginious/backend/agent/simple_agent.py
@@ -556,24 +556,24 @@ class SimpleAgent(object):
         return True
 
     def _student_container_get_stdin(self, container_id):
-        self.logger.info("Getting stdin of student container")
+        self.logger.debug("Getting stdin of student container")
         try:
             docker_connection = docker.Client(**kwargs_from_env())
         except:
-            self.logger.warning("Cannot connect to Docker!")
+            self.logger.error("Cannot connect to Docker!")
             return None
 
         stdin = docker_connection.attach_socket(container_id, {'stdin': 1, 'stderr': 0, 'stdout': 0, 'stream': 1})
-        self.logger.info("Returning stdin of student container")
+        self.logger.debug("Returning stdin of student container")
         return stdin
 
     def _student_container_close(self, container_id, container_set):
-        self.logger.info("Closing student container")
+        self.logger.debug("Closing student container")
 
         try:
             docker_connection = docker.Client(**kwargs_from_env())
         except:
-            self.logger.warning("Cannot connect to Docker!")
+            self.logger.error("Cannot connect to Docker!")
             return 254
 
         # Wait for completion
@@ -711,5 +711,5 @@ class SimpleAgent(object):
             docker_connection.kill(container_id)
             return True
         except Exception as e:
-            self.logger.info("Cannot kill container %s: %s", container_id, str(e))
+            self.logger.error("Cannot kill container %s: %s", container_id, str(e))
             return False

--- a/inginious/backend/agent/start_container_agent.py
+++ b/inginious/backend/agent/start_container_agent.py
@@ -50,8 +50,10 @@ if __name__ == "__main__":
 
     base = os.path.abspath(os.path.join(mounted_dir, "../"))
     if not os.path.exists(base):
+        logger.debug("mkdir " + base)
         os.makedirs(base)
     if not os.path.exists(mounted_dir):
+        logger.debug("symlink " + mounted_dir)
         os.symlink("/agent_volume", mounted_dir)
 
     agent_ssh_port = os.environ.get('AGENT_SSH_PORT')

--- a/inginious/common/tasks.py
+++ b/inginious/common/tasks.py
@@ -56,7 +56,6 @@ class Task(object):
         for problemid in self._data['problems']:
             self._problems.append(self._create_task_problem(problemid, self._data['problems'][problemid], task_problem_types))
 
-        self._lti_grader_method = self._data.get("lti_grader_method", "max")
 
     def input_is_consistent(self, task_input, default_allowed_extension, default_max_size):
         """ Check if an input for a task is consistent. Return true if this is case, false else """
@@ -76,10 +75,6 @@ class Task(object):
     def get_problems(self):
         """ Get problems contained in this task """
         return self._problems
-
-    def get_lti_grader_method(self):
-        """ Get the grader method for this task """
-        return self._lti_grader_method
 
     def get_course_id(self):
         """ Return the courseid of the course that contains this task """

--- a/inginious/common/tasks.py
+++ b/inginious/common/tasks.py
@@ -56,6 +56,8 @@ class Task(object):
         for problemid in self._data['problems']:
             self._problems.append(self._create_task_problem(problemid, self._data['problems'][problemid], task_problem_types))
 
+        self._lti_grader_method = self._data.get("lti_grader_method", "max")
+
     def input_is_consistent(self, task_input, default_allowed_extension, default_max_size):
         """ Check if an input for a task is consistent. Return true if this is case, false else """
         for problem in self._problems:
@@ -74,6 +76,10 @@ class Task(object):
     def get_problems(self):
         """ Get problems contained in this task """
         return self._problems
+
+    def get_lti_grader_method(self):
+        """ Get the grader method for this task """
+        return self._lti_grader_method
 
     def get_course_id(self):
         """ Return the courseid of the course that contains this task """

--- a/inginious/frontend/common/submission_manager.py
+++ b/inginious/frontend/common/submission_manager.py
@@ -101,8 +101,7 @@ class SubmissionManager(object):
             "status": "waiting",
             "submitted_on": datetime.now(),
             "username": [username],
-            "response_type": task.get_response_type(),
-            "lti_grader_method" : task.get_lti_grader_method()
+            "response_type": task.get_response_type()
         }
 
         self._before_submission_insertion(task, inputdata, debug, obj)

--- a/inginious/frontend/common/submission_manager.py
+++ b/inginious/frontend/common/submission_manager.py
@@ -101,7 +101,8 @@ class SubmissionManager(object):
             "status": "waiting",
             "submitted_on": datetime.now(),
             "username": [username],
-            "response_type": task.get_response_type()
+            "response_type": task.get_response_type(),
+            "lti_grader_method" : task.get_lti_grader_method()
         }
 
         self._before_submission_insertion(task, inputdata, debug, obj)

--- a/inginious/frontend/lti/app.py
+++ b/inginious/frontend/lti/app.py
@@ -163,7 +163,10 @@ def get_app(config, active_callback=None):
     template_helper.add_to_template_globals("default_max_file_size", default_max_file_size)
 
     # Not found page
-    appli.notfound = lambda: web.notfound(template_helper.get_renderer().notfound('Page not found'))
+    if config.get('log_level', 'DEBUG') == 'DEBUG':
+        appli.notfound = lambda: web.internalerror()
+    else:
+        appli.notfound = lambda: web.notfound(template_helper.get_renderer().notfound('Page not found'))
 
     # Init the mapping of the app
     appli.init_mapping(WebPyCustomMapping(dict(urls), plugin_manager,

--- a/inginious/frontend/lti/lis_outcome_manager.py
+++ b/inginious/frontend/lti/lis_outcome_manager.py
@@ -44,12 +44,12 @@ class LisOutcomeManager(threading.Thread):
 
                 try:
                     grade = self._user_manager.get_task_grade(self._course_factory.get_task(courseid, taskid), username)
-                    grade = grade / 100
+                    grade = grade / 100.0
                     if grade > 1:
                         grade = 1
                     if grade < 0:
                         grade = 0
-                except:
+                except Exception as e:
                     self._logger.error("An exception occured while getting a grade in LisOutcomeManager.", exc_info=True)
                     continue
 

--- a/inginious/frontend/lti/pages/download.py
+++ b/inginious/frontend/lti/pages/download.py
@@ -12,6 +12,9 @@ import shutil
 
 from inginious.frontend.lti.pages.utils import LTIAuthenticatedPage
 
+##
+## This needs to be provided by a config parameter, but i'm not certain how yet - dcg
+##
 if os.path.exists(os.path.join("lti_download", "tmp")):
     shutil.rmtree(os.path.join("lti_download", "tmp"))
 os.mkdir(os.path.join("lti_download", "tmp"))

--- a/inginious/frontend/lti/user_manager.py
+++ b/inginious/frontend/lti/user_manager.py
@@ -117,21 +117,11 @@ class UserManager(AbstractUserManager):
         grades =  self._database.submissions.find({"username": username, "courseid": task.get_course_id(),
                                                    "taskid": task.get_id(),
                                                    "status": "done"})
-
-        #
-        # Backwards compatability - if it's not specified, it should be max
-        #
-        grader = task.get_lti_grader_method() or 'max'
+        grader = task.get_evaluate()
         if grader == 'last':
             val = list(grades.sort([("submitted_on", pymongo.DESCENDING)]).limit(1))
-        elif grader == 'first':
-            val = list(grades.sort([("submitted_on", pymongo.ASCENDING)]).limit(1))
-        elif grader == 'max':
-            val = list(grades.sort([("grade", pymongo.ASCENDING)]).limit(1))
-        elif grader == 'min':
-            val = list(grades.sort([("grade", pymongo.DESCENDING)]).limit(1))
         else:
-            val = list(grades.limit(1))
+            val = list(grades.sort([("grade", pymongo.ASCENDING)]).limit(1))
         return val
 
 

--- a/inginious/frontend/lti/user_manager.py
+++ b/inginious/frontend/lti/user_manager.py
@@ -11,6 +11,7 @@ from inginious.frontend.common.user_manager import AbstractUserManager
 
 
 class UserManager(AbstractUserManager):
+
     def __init__(self, session, database):
         """
         :type session: inginious.frontend.lti.custom_session.CustomSession
@@ -105,6 +106,35 @@ class UserManager(AbstractUserManager):
         for key, val in value.iteritems():
             self._session[key] = val
 
+    def _get_task_grade_list(self, task, username):
+        """
+        Refactoring grade extraction code to simplify ordering
+        :param task: a Task object
+        :param username: The username of the user for who we want to retrieve the grade. If None, uses self.session_username()
+        :return: list of grades
+        """
+
+        grades =  self._database.submissions.find({"username": username, "courseid": task.get_course_id(),
+                                                   "taskid": task.get_id(),
+                                                   "status": "done"})
+
+        #
+        # Backwards compatability - if it's not specified, it should be max
+        #
+        grader = task.get_lti_grader_method() or 'max'
+        if grader == 'last':
+            val = list(grades.sort([("submitted_on", pymongo.DESCENDING)]).limit(1))
+        elif grader == 'first':
+            val = list(grades.sort([("submitted_on", pymongo.ASCENDING)]).limit(1))
+        elif grader == 'max':
+            val = list(grades.sort([("grade", pymongo.ASCENDING)]).limit(1))
+        elif grader == 'min':
+            val = list(grades.sort([("grade", pymongo.DESCENDING)]).limit(1))
+        else:
+            val = list(grades.limit(1))
+        return val
+
+
     def get_task_status(self, task, username=None):
         """
         :param task: a Task object
@@ -112,10 +142,7 @@ class UserManager(AbstractUserManager):
         :return: "succeeded" if the current user solved this task, "failed" if he failed, and "notattempted" if he did not try it yet
         """
         username = username or self.session_username()
-
-        val = list(self._database.submissions.find({"username": username, "courseid": task.get_course_id(), "taskid": task.get_id(),
-                                                    "status": "done"}).sort([("grade", pymongo.DESCENDING)]).limit(1))
-
+        val = self._get_task_grade_list(task, username)
         if len(val) == 1:
             if val[0]["result"] == "success":
                 return "succeeded"
@@ -130,9 +157,7 @@ class UserManager(AbstractUserManager):
         :return: a floating point number (percentage of max grade)
         """
         username = username or self.session_username()
-
-        val = list(self._database.submissions.find({"username": username, "courseid": task.get_course_id(), "taskid": task.get_id(),
-                                                    "status": "done"}).sort([("grade", pymongo.DESCENDING)]).limit(1))
+        val = self._get_task_grade_list(task, username)
         if len(val) == 1:
             return float(val[0]["grade"])
         return 0.0


### PR DESCRIPTION
In the current version of the LTI interface, the lis_outcome_manager always reports the MAX score to the TC (i.e. your LMS gradebook).  I initially added another field to the task items (lti_grader_method) and then saw that I should really use the 'evaluate' method.

I'm not completely happy with this because I would like to have the option of setting the grading method (last/best) in the custom_grading field so that instructors can use the same questions in formative and summative assessment. However, in the current setup, the LTI parameters are not available when doing the evaluation, so this will have to do.