### PR TITLE
Patch specify lti username

### DIFF
--- a/inginious/frontend/lti/app.py
+++ b/inginious/frontend/lti/app.py
@@ -150,7 +150,7 @@ def get_app(config, active_callback=None):
     if lti_user_name not in ['user_id', 'ext_user_username'] :
         lti_user_name = 'user_id'
 
-    user_manager = UserManager(CustomSession(appli, MongoStore(database, 'sessions')), database)
+    user_manager = UserManager(CustomSession(appli, MongoStore(database, 'sessions')), database, lti_user_name)
 
     backend_interface.update_pending_jobs(database)
 

--- a/inginious/frontend/lti/app.py
+++ b/inginious/frontend/lti/app.py
@@ -140,6 +140,16 @@ def get_app(config, active_callback=None):
 
     course_factory, task_factory = create_factories(task_directory, plugin_manager, FrontendCourse, FrontendTask)
 
+    #
+    # Allow user config to over-rider the username strong in Mongo.
+    # This is enabled by most LMS's such as Moodle, and the ext_user_username
+    # is the "login name" for the user, which is typically the same as
+    # would be authenticated by logging into the course via ldap
+    #
+    lti_user_name = config.get('lti_user_name', 'user_id')
+    if lti_user_name not in ['user_id', 'ext_user_username'] :
+        lti_user_name = 'user_id'
+
     user_manager = UserManager(CustomSession(appli, MongoStore(database, 'sessions')), database)
 
     backend_interface.update_pending_jobs(database)

--- a/inginious/frontend/lti/pages/utils.py
+++ b/inginious/frontend/lti/pages/utils.py
@@ -165,6 +165,10 @@ class LTILaunchPage(LTIPage):
 
         if verified:
             user_id = post_input["user_id"]
+            if 'ext_user_username' in post_input:
+                ext_user_username = post_input['ext_user_username']
+            else:
+                ext_user_username = user_id
             roles = post_input.get("roles", "Student").split(",")
             realname = self._find_realname(post_input)
             email = post_input.get("lis_person_contact_email_primary", "")
@@ -177,7 +181,7 @@ class LTILaunchPage(LTIPage):
             if outcome_result_id is None:
                 raise Exception("INGInious needs the parameter lis_result_sourcedid in the LTI basic-launch-request")
 
-            self.user_manager.lti_auth(user_id, roles, realname, email, courseid, taskid, consumer_key, lis_outcome_service_url, outcome_result_id)
+            self.user_manager.lti_auth(user_id, roles, realname, email, courseid, taskid, consumer_key, lis_outcome_service_url, outcome_result_id, ext_user_username)
         else:
             raise Exception("Cannot authentify request (2)")
 

--- a/inginious/frontend/lti/user_manager.py
+++ b/inginious/frontend/lti/user_manager.py
@@ -11,13 +11,14 @@ from inginious.frontend.common.user_manager import AbstractUserManager
 
 
 class UserManager(AbstractUserManager):
-    def __init__(self, session, database):
+    def __init__(self, session, database, lti_user_name):
         """
         :type session: inginious.frontend.lti.custom_session.CustomSession
         :type database: pymongo.database.Database
         """
         self._session = session
         self._database = database
+        self._lti_user_name = lti_user_name
 
     def session_logged_in(self):
         """ Returns True if a user is currently connected in this session, False else """
@@ -72,11 +73,11 @@ class UserManager(AbstractUserManager):
             return None
         return self._get_session_dict()["outcome_result_id"]
 
-    def lti_auth(self, user_id, roles, realname, email, course_id, task_id, consumer_key, outcome_service_url, outcome_result_id):
+    def lti_auth(self, user_id, roles, realname, email, course_id, task_id, consumer_key, outcome_service_url, outcome_result_id, ext_user_username):
         """ LTI Auth """
         self._set_session_dict({
             "email": email,
-            "username": user_id,
+            "username": ext_user_username if self._lti_user_name == 'ext_user_username' else user_id,
             "realname": realname,
             "roles": roles,
             "task": (course_id, task_id),


### PR DESCRIPTION
the LTI standard uses "user_id" as the user identifier, but most LMS's also support ext_user_username, which is typically the unique identifier for the person (e.g. in moodle, this is the account name).

We use a SSO system with ldap + shib, and would like to have the data in the Moodle and Inginious key off the same name rather than the numeric ID of the moodle user.

grade changes back to the Moodle TC still work with this change. Users can specify lti_user_name: ext_user_username in the YAML config file.

Forgot to add a doc for it, but can do it if this patch is OK.