### PR TITLE
enroll LTI users if autoenroll is true

### DIFF
--- a/doc/install_doc/config_reference.rst
+++ b/doc/install_doc/config_reference.rst
@@ -62,6 +62,24 @@ The different entries are :
     See :ref:`plugins` for detailed information on available plugins, including their configuration.
 
 .. _configuration.example.yaml: https://github.com/UCL-INGI/INGInious/blob/master/configuration.example.yaml
+
+LTI Configuration reference
+=======================
+The LTI interface uses most of the same configuration options as the webapp as well as the following:
+
+``lti``
+    A list of LTI consumer key and secret values
+
+``lti_user_name``
+    The LTI field used to identify the user. By default this is "user_id", which for many LMS system would be
+    the numeric ID of the user. It can be set to `ext_user_username` which is often a unique username.
+
+``autoenroll``
+    If true, submissions pass through LTI have the user be automatically enrolled in the class, allowing
+    downloading of submissions and bulk operations if needed.
+
+.. _configuration.example.yaml: https://github.com/UCL-INGI/INGInious/blob/master/configuration.lti.example.yaml
+
 .. _docker-py API: https://github.com/docker/docker-py/blob/master/docs/api.md#client-api
 
 .. _plugins:

--- a/inginious/frontend/lti/user_manager.py
+++ b/inginious/frontend/lti/user_manager.py
@@ -11,13 +11,15 @@ from inginious.frontend.common.user_manager import AbstractUserManager
 
 
 class UserManager(AbstractUserManager):
-    def __init__(self, session, database):
+
+    def __init__(self, session, database, lti_user_name):
         """
         :type session: inginious.frontend.lti.custom_session.CustomSession
         :type database: pymongo.database.Database
         """
         self._session = session
         self._database = database
+        self._lti_user_name = lti_user_name
 
     def session_logged_in(self):
         """ Returns True if a user is currently connected in this session, False else """
@@ -72,17 +74,18 @@ class UserManager(AbstractUserManager):
             return None
         return self._get_session_dict()["outcome_result_id"]
 
-    def lti_auth(self, user_id, roles, realname, email, course_id, task_id, consumer_key, outcome_service_url, outcome_result_id):
+    def lti_auth(self, user_id, roles, realname, email, course_id, task_id, consumer_key, 
+                 outcome_service_url, outcome_result_id, ext_user_username):
         """ LTI Auth """
         self._set_session_dict({
             "email": email,
-            "username": user_id,
+            "username": ext_user_username if self._lti_user_name == 'ext_user_username' else user_id,
             "realname": realname,
             "roles": roles,
             "task": (course_id, task_id),
             "outcome_service_url": outcome_service_url,
             "outcome_result_id": outcome_result_id,
-            "consumer_key": consumer_key
+            "consumer_key": consumer_key,
         })
 
     def get_session_identifier(self):
@@ -105,6 +108,25 @@ class UserManager(AbstractUserManager):
         for key, val in value.iteritems():
             self._session[key] = val
 
+    def _get_task_grade_list(self, task, username):
+        """
+        Refactoring grade extraction code to simplify ordering
+        :param task: a Task object
+        :param username: The username of the user for who we want to retrieve the grade. If None, uses self.session_username()
+        :return: list of grades
+        """
+
+        grades =  self._database.submissions.find({"username": username, "courseid": task.get_course_id(),
+                                                   "taskid": task.get_id(),
+                                                   "status": "done"})
+        grader = task.get_evaluate()
+        if grader == 'last':
+            val = list(grades.sort([("submitted_on", pymongo.DESCENDING)]).limit(1))
+        else:
+            val = list(grades.sort([("grade", pymongo.ASCENDING)]).limit(1))
+        return val
+
+
     def get_task_status(self, task, username=None):
         """
         :param task: a Task object
@@ -112,10 +134,7 @@ class UserManager(AbstractUserManager):
         :return: "succeeded" if the current user solved this task, "failed" if he failed, and "notattempted" if he did not try it yet
         """
         username = username or self.session_username()
-
-        val = list(self._database.submissions.find({"username": username, "courseid": task.get_course_id(), "taskid": task.get_id(),
-                                                    "status": "done"}).sort([("grade", pymongo.DESCENDING)]).limit(1))
-
+        val = self._get_task_grade_list(task, username)
         if len(val) == 1:
             if val[0]["result"] == "success":
                 return "succeeded"
@@ -123,16 +142,83 @@ class UserManager(AbstractUserManager):
                 return "failed"
         return "notattempted"
 
+    def get_task_result_grade(self, task, username=None):
+        """
+        :param task: a Task object
+        :param username: The username of the user for who we want to retrieve the grade. If None, uses self.session_username()
+        :return: "success" or "failure", a floating point number (percentage of max grade)
+        """
+        username = username or self.session_username()
+        val = self._get_task_grade_list(task, username)
+        if len(val) == 1:
+            return val[0]["result"], float(val[0]["grade"])
+        else:
+            return "failure", 0.0
+
     def get_task_grade(self, task, username=None):
         """
         :param task: a Task object
         :param username: The username of the user for who we want to retrieve the grade. If None, uses self.session_username()
         :return: a floating point number (percentage of max grade)
         """
-        username = username or self.session_username()
+        result,grade = self.get_task_result_grade(task, username)
+        return grade
 
-        val = list(self._database.submissions.find({"username": username, "courseid": task.get_course_id(), "taskid": task.get_id(),
-                                                    "status": "done"}).sort([("grade", pymongo.DESCENDING)]).limit(1))
-        if len(val) == 1:
-            return float(val[0]["grade"])
-        return 0.0
+    def user_saw_task(self, username, courseid, taskid):
+        """ Set in the database that the user has viewed this task """
+        self._database.user_tasks.update({"username": username, "courseid": courseid, "taskid": taskid},
+                                         {"$setOnInsert": {"username": username, "courseid": courseid, "taskid": taskid,
+                                                           "tried": 0, "succeeded": False, "grade": 0.0, "submissionid": None}},
+                                         upsert=True)
+
+    def update_user_stats(self, username, task, submission, result, grade):
+        """ Update stats with a new submission """
+        self.user_saw_task(username, submission["courseid"], submission["taskid"])
+
+        old_submission = self._database.user_tasks.find_one_and_update(
+            {"username": username, "courseid": submission["courseid"], "taskid": submission["taskid"]}, {"$inc": {"tried": 1}})
+
+        # Check if the submission is the default download
+        set_default = task.get_evaluate() == 'last' or \
+                      (task.get_evaluate() == 'student' and old_submission is None) or \
+                      (task.get_evaluate() == 'best' and old_submission.get('grade', 0.0) <= grade)
+
+        if set_default:
+            self._database.user_tasks.find_one_and_update(
+                {"username": username, "courseid": submission["courseid"], "taskid": submission["taskid"]},
+                {"$set": {"succeeded": result == "success", "grade": grade,"submissionid": submission['_id']}})
+
+    def course_is_user_registered(self, course, username=None):
+        """
+        Checks if a user is registered
+        :param course: a Course object
+        :param username: The username of the user that we want to check. If None, uses self.session_username()
+        :return: True if the user is registered, False else
+        """
+        if username is None:
+            username = self.session_username()
+
+        return self._database.aggregations.find_one({"students": username, "courseid": course.get_id()}) is not None
+
+    def course_register_user(self, course, username, email, realname):
+        """
+        Register a user to the course
+        :param course: a Course object
+        :param username: The username of the user that we want to register. If None, uses self.session_username()
+        :param password: Password for the course. Needed if course.is_password_needed_for_registration() and force != True
+        :param force: Force registration
+        :return: True if the registration succeeded, False else
+        """
+
+        if self.course_is_user_registered(course, username):
+            return False  # already registered?
+
+        aggregation = self._database.aggregations.find_one({"courseid": course.get_id(), "default": True})
+        if aggregation is None:
+            self._database.aggregations.insert({"courseid": course.get_id(), "description": "Default classroom",
+                                              "students": [username], "tutors": [], "groups": [], "default": True})
+        else:
+            self._database.aggregations.find_one_and_update({"courseid": course.get_id(), "default": True},
+                                                          {"$push": {"students": username}})
+
+        return True


### PR DESCRIPTION
This PR implementations a solution to the issue I posted. If your LTI config file sets "autoenroll: True", then requests submitted via LTI cause the student to be enrolled in the course and to have a users_task record to be added to the MongoDB.

The end result is that you can download the submissions via the webapp and I think you should be able to run "batch items" against the submissions (haven't tried).

Ideally, this would have some method to create a "classroom" that uses the LTI provided course information.

Also included documentation updates.