### PR TITLE
Improve the usage of TemplateHelper outside of the main source (for p…

### DIFF
--- a/inginious-lti
+++ b/inginious-lti
@@ -87,7 +87,7 @@ if __name__ == "__main__":
     application = CustomLogMiddleware(application, logging.getLogger("inginious.lti.requests"))
 
     # Launch the app
-    server = web.httpserver.WSGIServer((args.host, int(args.port)), application)
+    server = web.httpserver.WSGIServer((host, int(port)), application)
     try:
         server.start()
     except KeyboardInterrupt:

--- a/inginious-lti
+++ b/inginious-lti
@@ -79,7 +79,7 @@ if __name__ == "__main__":
     signal.signal(signal.SIGTERM, lambda _, _2: close_app_signal())
 
     # Add static redirection and request log
-    root_path = inginious.frontend.lti.app.get_root_path()
+    root_path = inginious.get_root_path()
     application = StaticMiddleware(application, (
         ('/static/common/', os.path.join(root_path, 'frontend', 'common', 'static')),
         ('/static/lti/', os.path.join(root_path, 'frontend', 'lti', 'static'))

--- a/inginious-webapp
+++ b/inginious-webapp
@@ -80,7 +80,7 @@ if __name__ == "__main__":
     signal.signal(signal.SIGTERM, lambda _, _2: close_app_signal())
 
     # Add static redirection and request log
-    root_path = inginious.frontend.webapp.app.get_root_path()
+    root_path = inginious.get_root_path()
     application = StaticMiddleware(application, (
         ('/static/common/', os.path.join(root_path, 'frontend', 'common', 'static')),
         ('/static/webapp/', os.path.join(root_path, 'frontend', 'webapp', 'static'))

--- a/inginious-webapp
+++ b/inginious-webapp
@@ -88,7 +88,7 @@ if __name__ == "__main__":
     application = CustomLogMiddleware(application, logging.getLogger("inginious.webapp.requests"))
 
     # Launch the app
-    server = web.httpserver.WSGIServer((args.host, int(args.port)), application)
+    server = web.httpserver.WSGIServer((host, int(port)), application)
     try:
         server.start()
     except KeyboardInterrupt:

--- a/inginious/__init__.py
+++ b/inginious/__init__.py
@@ -4,4 +4,11 @@
 # more information about the licensing of this file.
 #
 
+import os
+
 __version__ = "0.3a2.dev0"
+
+
+def get_root_path():
+    """ Returns the INGInious root path """
+    return os.path.abspath(os.path.dirname(__file__))

--- a/inginious/frontend/common/template_helper.py
+++ b/inginious/frontend/common/template_helper.py
@@ -12,11 +12,9 @@ import inginious
 class TemplateHelper(object):
     """ Class accessible from templates that calls function defined in the Python part of the code. """
 
-    """
-    _WEB_CTX_KEY is the name of the key in web.ctx that stores entries made available to the whole
-    current thread. It allows to store javascript/css "addons" that will be displayed later when the
-    templates are rendered
-    """
+    # _WEB_CTX_KEY is the name of the key in web.ctx that stores entries made available to the whole
+    # current thread. It allows to store javascript/css "addons" that will be displayed later when the
+    # templates are rendered
     _WEB_CTX_KEY = "inginious_tpl_helper"
 
     def __init__(self, plugin_manager, default_template_dir, default_layout, use_minified=True):

--- a/inginious/frontend/lti/app.py
+++ b/inginious/frontend/lti/app.py
@@ -5,7 +5,6 @@
 
 """ Starts the webapp """
 import logging
-import os
 
 from gridfs import GridFS
 from pymongo import MongoClient

--- a/inginious/frontend/lti/app.py
+++ b/inginious/frontend/lti/app.py
@@ -123,7 +123,7 @@ def get_app(config):
     submission_manager = LTISubmissionManager(client, user_manager, database, gridfs, plugin_manager,
                                               config.get('nb_submissions_kept', 5), lis_outcome_manager)
 
-    template_helper = TemplateHelper(plugin_manager, get_root_path(), 'frontend/lti/templates', 'layout', config.get('use_minified_js', True))
+    template_helper = TemplateHelper(plugin_manager, 'frontend/lti/templates', 'frontend/lti/templates/layout', config.get('use_minified_js', True))
 
     # Update the database
     update_database(database)
@@ -161,8 +161,3 @@ def get_app(config):
     client.start()
 
     return appli.wsgifunc(), lambda: _close_app(appli, mongo_client, client, lis_outcome_manager)
-
-
-def get_root_path():
-    """ Returns the INGInious root path """
-    return os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))

--- a/inginious/frontend/webapp/app.py
+++ b/inginious/frontend/webapp/app.py
@@ -12,6 +12,7 @@ from pymongo import MongoClient
 import web
 from web.debugerror import debugerror
 
+import inginious
 from inginious.frontend.common.arch_helper import create_arch, start_asyncio_and_zmq
 from inginious.frontend.webapp.database_updater import update_database
 from inginious.frontend.common.plugin_manager import PluginManager
@@ -130,7 +131,8 @@ def get_app(config):
     batch_manager = BatchManager(client, database, gridfs, submission_manager, user_manager,
                                  task_directory)
 
-    template_helper = TemplateHelper(plugin_manager, get_root_path(), 'frontend/webapp/templates', 'layout', config.get('use_minified_js', True))
+    template_helper = TemplateHelper(plugin_manager, 'frontend/webapp/templates', 'frontend/webapp/templates/layout',
+                                     config.get('use_minified_js', True))
 
     # Init web mail
     smtp_conf = config.get('smtp', None)
@@ -185,8 +187,3 @@ def get_app(config):
     client.start()
 
     return appli.wsgifunc(), lambda: _close_app(appli, mongo_client, client)
-
-
-def get_root_path():
-    """ Returns the INGInious root path """
-    return os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))

--- a/inginious/frontend/webapp/app.py
+++ b/inginious/frontend/webapp/app.py
@@ -4,15 +4,11 @@
 # more information about the licensing of this file.
 
 """ Starts the webapp """
-import logging
-import os
-
 from gridfs import GridFS
 from pymongo import MongoClient
 import web
 from web.debugerror import debugerror
 
-import inginious
 from inginious.frontend.common.arch_helper import create_arch, start_asyncio_and_zmq
 from inginious.frontend.webapp.database_updater import update_database
 from inginious.frontend.common.plugin_manager import PluginManager

--- a/inginious/frontend/webapp/pages/maintenance.py
+++ b/inginious/frontend/webapp/pages/maintenance.py
@@ -13,10 +13,8 @@ class MaintenancePage(INGIniousPage):
 
     def GET(self):
         """ GET request """
-        renderer = self.template_helper.get_custom_template_renderer('frontend/templates/')
-        return renderer.maintenance()
+        return self.template_helper.get_renderer(False).maintenance()
 
     def POST(self):
         """ POST request """
-        renderer = self.template_helper.get_custom_template_renderer('frontend/templates/')
-        return renderer.maintenance()
+        return self.template_helper.get_renderer(False).maintenance()

--- a/inginious/frontend/webapp/plugins/auth/db_auth.py
+++ b/inginious/frontend/webapp/plugins/auth/db_auth.py
@@ -84,7 +84,7 @@ class RegistrationPage(INGIniousPage):
             else:
                 reset = {"hash": data["reset"], "username": user["username"], "realname": user["realname"]}
 
-        return self.template_helper.get_custom_template_renderer('frontend/webapp/templates', 'layout').register(reset, msg, error)
+        return self.template_helper.get_renderer().register(reset, msg, error)
 
     def register_user(self, data):
         """ Parses input and register user """
@@ -209,7 +209,7 @@ Someone (probably you) asked to reset your INGInious password. If this was you, 
         elif "resetpasswd" in data:
             msg, error = self.reset_passwd(data)
 
-        return self.template_helper.get_custom_template_renderer('frontend/webapp/templates', 'layout').register(reset, msg, error)
+        return self.template_helper.get_renderer().register(reset, msg, error)
 
 
 def init(plugin_manager, _, _2, conf):

--- a/inginious/frontend/webapp/plugins/contests/contests.py
+++ b/inginious/frontend/webapp/plugins/contests/contests.py
@@ -61,7 +61,7 @@ def course_menu(course, template_helper):
         start = datetime.strptime(contest_data['start'], "%Y-%m-%d %H:%M:%S")
         end = datetime.strptime(contest_data['end'], "%Y-%m-%d %H:%M:%S")
         blackout = end - timedelta(hours=contest_data['blackout'])
-        return str(template_helper.get_custom_template_renderer('webapp/plugins/contests').course_menu(course, start, end, blackout))
+        return str(template_helper.get_custom_renderer('frontend/webapp/plugins/contests', layout=False).course_menu(course, start, end, blackout))
     else:
         return None
 
@@ -152,7 +152,7 @@ class ContestScoreboard(INGIniousPage):
                 results[user]["rank"] = current_rank
                 results[user]["displayed_rank"] = ""
 
-        return self.template_helper.get_custom_template_renderer('webapp/plugins/contests', '../../templates/layout'). \
+        return self.template_helper.get_custom_renderer('frontend/webapp/plugins/contests').\
             scoreboard(course, start, end, blackout, tasks, results, activity)
 
 
@@ -163,8 +163,7 @@ class ContestAdmin(INGIniousAdminPage):
         """ GET request: simply display the form """
         course, _ = self.get_course_and_check_rights(courseid, allow_all_staff=False)
         contest_data = get_contest_data(course)
-        return self.template_helper.get_custom_template_renderer('webapp/plugins/contests', '../../templates/layout'). \
-            admin(course, contest_data, None, False)
+        return self.template_helper.get_custom_renderer('frontend/webapp/plugins/contests').admin(course, contest_data, None, False)
 
     def POST(self, courseid):
         """ POST request: update the settings """
@@ -210,11 +209,9 @@ class ContestAdmin(INGIniousAdminPage):
 
         if len(errors) == 0:
             save_contest_data(course, contest_data)
-            return self.template_helper.get_custom_template_renderer('webapp/plugins/contests', '../../templates/layout'). \
-                admin(course, contest_data, None, True)
+            return self.template_helper.get_custom_renderer('frontend/webapp/plugins/contests').admin(course, contest_data, None, True)
         else:
-            return self.template_helper.get_custom_template_renderer('webapp/plugins/contests', '../../templates/layout'). \
-                admin(course, contest_data, errors, False)
+            return self.template_helper.get_custom_renderer('frontend/webapp/plugins/contests').admin(course, contest_data, errors, False)
 
 
 def init(plugin_manager, course_factory, client, _config):

--- a/inginious/frontend/webapp/plugins/scoreboard/__init__.py
+++ b/inginious/frontend/webapp/plugins/scoreboard/__init__.py
@@ -26,7 +26,7 @@ class ScoreBoardCourse(INGIniousPage):
         if len(names) == 0:
             raise web.notfound()
 
-        return self.template_helper.get_custom_template_renderer('frontend/webapp/plugins/scoreboard', '../../templates/layout').main(course, names)
+        return self.template_helper.get_custom_renderer('frontend/webapp/plugins/scoreboard').main(course, names)
 
 def sort_func(overall_result_per_user, reversed):
     def sf(user):
@@ -158,7 +158,7 @@ class ScoreBoard(INGIniousPage):
 
             table.append(line)
 
-        renderer = self.template_helper.get_custom_template_renderer('frontend/webapp/plugins/scoreboard', '../../templates/layout')
+        renderer = self.template_helper.get_custom_renderer('frontend/webapp/plugins/scoreboard')
         return renderer.scoreboard(course, scoreboardid, scoreboard_name, header, table, emphasized_columns)
 
 
@@ -167,7 +167,7 @@ def course_menu(course, template_helper):
     scoreboards = course.get_descriptor().get('scoreboard', [])
 
     if scoreboards != []:
-        return str(template_helper.get_custom_template_renderer('frontend/webapp/plugins/scoreboard').course_menu(course))
+        return str(template_helper.get_custom_renderer('frontend/webapp/plugins/scoreboard', layout=False).course_menu(course))
     else:
         return None
 
@@ -181,7 +181,7 @@ def task_menu(course, task, template_helper):
                 tolink.append((sid, scoreboard["name"]))
 
         if tolink:
-            return str(template_helper.get_custom_template_renderer('frontend/webapp/plugins/scoreboard').task_menu(course, tolink))
+            return str(template_helper.get_custom_renderer('frontend/webapp/plugins/scoreboard', layout=False).task_menu(course, tolink))
         return None
     except:
         return None


### PR DESCRIPTION
…lugins) by selecting by default the base layout.

Remove improper passing of the inginious package root path from the app to the helper, and the method added previously to get this path from TemplateHelper, which made no sense either.
Add instead a function get_root_path() in the INGInious package itself, which is of course always available.

This may break some plugin as the newly "layout" param for get_custom_renderer has not the same signification;
I then changed the name of the method from get_custom_template_renderer to get_custom_renderer to make other devs notice the change.
The new name is also more consistent with the name of the other methods.


@anthonygego you should be happier now.