### PR TITLE
missing quotes for id in subproblem templates

### DIFF
--- a/inginious/frontend/webapp/templates/course_admin/edit_tabs/subproblem_templates.html
+++ b/inginious/frontend/webapp/templates/course_admin/edit_tabs/subproblem_templates.html
@@ -256,7 +256,7 @@ $#
                         <label for="choice-PID-CHOICE" class="col-sm-2 control-label">Content</label>
                         <div class="col-sm-10">
                             <textarea class="form-control subproblem_multiple_choice_text" name="problem[PID][choices][CHOICE][text]"
-                                      placeholder="The name of this choice" id=choice-PID-CHOICE"></textarea>
+                                      placeholder="The name of this choice" id="choice-PID-CHOICE"></textarea>
                         </div>
                     </div>
                     <div class="form-group">


### PR DESCRIPTION
For the multiple choice subproblem html template a quote was missing in textarea id.