### PR TITLE
Add a mechanism to support cookieless sessions

### DIFF
--- a/inginious/frontend/webapp/cookieless_app.py
+++ b/inginious/frontend/webapp/cookieless_app.py
@@ -1,0 +1,225 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INGInious. See the LICENSE and the COPYRIGHTS files for
+# more information about the licensing of this file.
+
+import os, time
+import os.path
+from copy import deepcopy
+import hashlib
+from web import utils
+import web
+from web.session import SessionExpired
+
+
+class CookieLessCompatibleApplication(web.application):
+    def __init__(self, session_storage):
+        """
+        :param session_storage: a Storage object, where sessions will be saved
+        """
+        super(CookieLessCompatibleApplication, self).__init__((), globals(), autoreload=False)
+        self._session = CookieLessCompatibleSession(self, session_storage)
+
+    def get_session(self):
+        return self._session
+
+    def init_mapping(self, mapping):
+        self.mapping = [(r"(/@[a-f0-9A-F_]*@)?" +a, b) for a,b in utils.group(mapping, 2)]
+    
+    def _delegate(self, f, fvars, args=None):
+        if args is None:
+            args = [None]
+
+        # load session
+        if args[0] == "/@@":
+            self._session.load('') # creates a new session
+            raise web.redirect("/@" + self._session.session_id + "@"+web.ctx.fullpath[3:]) # redirect to the same page, with the new
+            # session id
+        elif args[0] is None:
+            self._session.load(None)
+        else:
+            self._session.load(args[0][2:len(args[0])-1])
+
+        return super(CookieLessCompatibleApplication, self)._delegate(f, fvars, args[1:])
+
+    def get_homepath(self, ignore_session=False, force_cookieless=False):
+        """
+        :param ignore_session: Ignore the cookieless session_id that should be put in the URL
+        :param force_cookieless: Force the cookieless session; the link will include the session_creator if needed.
+        """
+        if not ignore_session and self._session.get("session_id") is not None and self._session.get("cookieless", False):
+            return web.ctx.homepath + "/@" + self._session.get("session_id") + "@"
+        elif not ignore_session and force_cookieless:
+            return web.ctx.homepath + "/@@"
+        else:
+            return web.ctx.homepath
+
+
+class CookieLessCompatibleSession(object):
+    """ A session that can either store its session id in a Cookie or directly in the webpage URL. 
+        The load(session_id) function must be called manually, in order for the session to be loaded. 
+        This is usually done by the CookieLessCompatibleApplication.
+        
+        Original code from web.py (public domain)
+    """
+
+    __slots__ = [
+        "store", "_initializer", "_last_cleanup_time", "_config", "_data", "_session_id_regex",
+        "__getitem__", "__setitem__", "__delitem__"
+    ]
+
+    def __init__(self, app, store, initializer=None):
+        self.store = store
+        self._initializer = initializer
+        self._last_cleanup_time = 0
+        self._config = utils.storage(web.config.session_parameters)
+        self._data = utils.threadeddict()
+        self._session_id_regex = utils.re_compile('^[0-9a-fA-F]+$')
+
+        self.__getitem__ = self._data.__getitem__
+        self.__setitem__ = self._data.__setitem__
+        self.__delitem__ = self._data.__delitem__
+
+        if app:
+            app.add_processor(self._processor)
+
+    def __contains__(self, name):
+        return name in self._data
+
+    def __getattr__(self, name):
+        return getattr(self._data, name)
+
+    def __setattr__(self, name, value):
+        if name in self.__slots__:
+            object.__setattr__(self, name, value)
+        else:
+            setattr(self._data, name, value)
+
+    def __delattr__(self, name):
+        delattr(self._data, name)
+
+    def _processor(self, handler):
+        """Application processor to setup session for every request"""
+
+        self._cleanup()
+
+        try:
+            return handler()
+        except Exception as e:
+            print(e)
+        finally:
+            self._save()
+
+    def load(self, session_id=None):
+        """ Load the session from the store.
+        session_id can be:
+        - None: load from cookie
+        - '': create a new cookieless session_id
+        - a string which is the session_id to be used.
+        """
+
+        if session_id is None:
+            cookie_name = self._config.cookie_name
+            self._data["session_id"] = web.cookies().get(cookie_name)
+            self._data["cookieless"] = False
+        else:
+            if session_id == '':
+                self._data["session_id"] = None  # will be created
+            else:
+                self._data["session_id"] = session_id
+            self._data["cookieless"] = True
+
+        # protection against session_id tampering
+        if self._data["session_id"] and not self._valid_session_id(self._data["session_id"]):
+            self._data["session_id"] = None
+
+        self._check_expiry()
+        if self._data["session_id"]:
+            d = self.store[self._data["session_id"]]
+            self.update(d)
+            self._validate_ip()
+
+        if not self._data["session_id"]:
+            self._data["session_id"] = self._generate_session_id()
+
+            if self._initializer:
+                if isinstance(self._initializer, dict):
+                    self.update(deepcopy(self._initializer))
+                elif hasattr(self._initializer, '__call__'):
+                    self._initializer()
+
+        self._data["ip"] = web.ctx.ip
+
+    def _check_expiry(self):
+        # check for expiry
+        if self._data["session_id"] and self._data["session_id"] not in self.store:
+            if self._config.ignore_expiry:
+                self._data["session_id"] = None
+            else:
+                return self.expired()
+
+    def _validate_ip(self):
+        # check for change of IP
+        if self._data["session_id"] and self.get('ip', None) != web.ctx.ip:
+            if not self._config.ignore_change_ip:
+                return self.expired()
+
+    def _save_cookieless(self):
+        if not self._data.get('_killed') and self._data["session_id"] is not None:
+            self.store[self._data["session_id"]] = dict(self._data)
+
+    def _save_cookie(self):
+        if not self.get('_killed'):
+            self._setcookie(self._data["session_id"])
+            self.store[self._data["session_id"]] = dict(self._data)
+        else:
+            self._setcookie(self._data["session_id"], expires=-1)
+
+    def _save(self):
+        if self._data.get("cookieless", False):
+            self._save_cookieless()
+        else:
+            self._save_cookie()
+
+    def _setcookie(self, session_id, expires='', **kw):
+        cookie_name = self._config.cookie_name
+        cookie_domain = self._config.cookie_domain
+        cookie_path = self._config.cookie_path
+        httponly = self._config.httponly
+        secure = self._config.secure
+        web.setcookie(cookie_name, session_id, expires=expires, domain=cookie_domain, httponly=httponly, secure=secure, path=cookie_path)
+
+    def _generate_session_id(self):
+        """Generate a random id for session"""
+
+        while True:
+            rand = os.urandom(16)
+            now = time.time()
+            secret_key = self._config.secret_key
+            session_id = hashlib.sha1(("%s%s%s%s" % (rand, now, utils.safestr(web.ctx.ip), secret_key)).encode("utf-8"))
+            session_id = session_id.hexdigest()
+            if session_id not in self.store:
+                break
+        return session_id
+
+    def _valid_session_id(self, session_id):
+        return self._session_id_regex.match(session_id)
+
+    def _cleanup(self):
+        """Cleanup the stored sessions"""
+        current_time = time.time()
+        timeout = self._config.timeout
+        if current_time - self._last_cleanup_time > timeout:
+            self.store.cleanup(timeout)
+            self._last_cleanup_time = current_time
+
+    def expired(self):
+        """Called when an expired session is atime"""
+        self._data["_killed"] = True
+        self._save()
+        raise SessionExpired(self._config.expired_message)
+
+    def kill(self):
+        """Kill the session, make it no longer available"""
+        del self.store[self.session_id]
+        self._data["_killed"] = True

--- a/inginious/frontend/webapp/cookieless_app.py
+++ b/inginious/frontend/webapp/cookieless_app.py
@@ -161,7 +161,7 @@ class CookieLessCompatibleSession(object):
     def _validate_ip(self):
         # check for change of IP
         if self._data["session_id"] and self.get('ip', None) != web.ctx.ip:
-            if not self._config.ignore_change_ip:
+            if not self._config.ignore_change_ip or self._data["cookieless"] is True:
                 return self.expired()
 
     def _save_cookieless(self):

--- a/inginious/frontend/webapp/templates/course_unavailable.html
+++ b/inginious/frontend/webapp/templates/course_unavailable.html
@@ -6,7 +6,7 @@ $#
 $var title: Course unavailable
 
 $# Start content
-<img src="$get_homepath()/static/common/images/logo_maintenance.png" style="margin:auto; display:block;"/>
+<img src="$get_homepath(True)/static/common/images/logo_maintenance.png" style="margin:auto; display:block;"/>
 <div class="alert alert-warning" role="alert" style="text-align: center;">
     <b>Error 403</b> You are not registered to this course.
 </div>

--- a/inginious/frontend/webapp/templates/layout.html
+++ b/inginious/frontend/webapp/templates/layout.html
@@ -13,62 +13,62 @@ $#
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="INGInious">
 <meta name="author" content="">
-<link rel="icon" href="$get_homepath()/static/common/icons/favicon.ico">
-<link rel="mask-icon" href="$get_homepath()/static/common/icons/wb.svg" color="#5E932E">
+<link rel="icon" href="$get_homepath(True)/static/common/icons/favicon.ico">
+<link rel="mask-icon" href="$get_homepath(True)/static/common/icons/wb.svg" color="#5E932E">
 
 <title>INGInious - $content.title</title>
 
 <!-- Bootstrap -->
-<link href="$get_homepath()/static/common/css/bootstrap.min.css" rel="stylesheet">
-<link href="$get_homepath()/static/common/css/bootstrap-datetimepicker.min.css" rel="stylesheet">
+<link href="$get_homepath(True)/static/common/css/bootstrap.min.css" rel="stylesheet">
+<link href="$get_homepath(True)/static/common/css/bootstrap-datetimepicker.min.css" rel="stylesheet">
 
 <!-- Font Awesome -->
-<link href="$get_homepath()/static/common/css/font-awesome.min.css" rel="stylesheet">
+<link href="$get_homepath(True)/static/common/css/font-awesome.min.css" rel="stylesheet">
 
 <!-- INGInious Style -->
-<link href="$get_homepath()/static/webapp/css/INGInious.css" rel="stylesheet">
+<link href="$get_homepath(True)/static/webapp/css/INGInious.css" rel="stylesheet">
 
 <!-- Codemirror Style -->
-<link href="$get_homepath()/static/common/css/codemirror.css" rel="stylesheet">
+<link href="$get_homepath(True)/static/common/css/codemirror.css" rel="stylesheet">
 
 <!-- Icons -->
-<link rel="shortcut icon" href="$get_homepath()/static/common/icons/favicon.ico">
-<link rel="apple-touch-icon" sizes="57x57" href="$get_homepath()/static/common/icons/apple-touch-icon-57x57.png">
-<link rel="apple-touch-icon" sizes="114x114" href="$get_homepath()/static/common/icons/apple-touch-icon-114x114.png">
-<link rel="apple-touch-icon" sizes="72x72" href="$get_homepath()/static/common/icons/apple-touch-icon-72x72.png">
-<link rel="apple-touch-icon" sizes="144x144" href="$get_homepath()/static/common/icons/apple-touch-icon-144x144.png">
-<link rel="apple-touch-icon" sizes="60x60" href="$get_homepath()/static/common/icons/apple-touch-icon-60x60.png">
-<link rel="apple-touch-icon" sizes="120x120" href="$get_homepath()/static/common/icons/apple-touch-icon-120x120.png">
-<link rel="apple-touch-icon" sizes="76x76" href="$get_homepath()/static/common/icons/apple-touch-icon-76x76.png">
-<link rel="apple-touch-icon" sizes="152x152" href="$get_homepath()/static/common/icons/apple-touch-icon-152x152.png">
-<link rel="icon" type="image/png" href="$get_homepath()/static/common/icons/favicon-196x196.png" sizes="196x196">
-<link rel="icon" type="image/png" href="$get_homepath()/static/common/icons/favicon-160x160.png" sizes="160x160">
-<link rel="icon" type="image/png" href="$get_homepath()/static/common/icons/favicon-96x96.png" sizes="96x96">
-<link rel="icon" type="image/png" href="$get_homepath()/static/common/icons/favicon-16x16.png" sizes="16x16">
-<link rel="icon" type="image/png" href="$get_homepath()/static/common/icons/favicon-32x32.png" sizes="32x32">
+<link rel="shortcut icon" href="$get_homepath(True)/static/common/icons/favicon.ico">
+<link rel="apple-touch-icon" sizes="57x57" href="$get_homepath(True)/static/common/icons/apple-touch-icon-57x57.png">
+<link rel="apple-touch-icon" sizes="114x114" href="$get_homepath(True)/static/common/icons/apple-touch-icon-114x114.png">
+<link rel="apple-touch-icon" sizes="72x72" href="$get_homepath(True)/static/common/icons/apple-touch-icon-72x72.png">
+<link rel="apple-touch-icon" sizes="144x144" href="$get_homepath(True)/static/common/icons/apple-touch-icon-144x144.png">
+<link rel="apple-touch-icon" sizes="60x60" href="$get_homepath(True)/static/common/icons/apple-touch-icon-60x60.png">
+<link rel="apple-touch-icon" sizes="120x120" href="$get_homepath(True)/static/common/icons/apple-touch-icon-120x120.png">
+<link rel="apple-touch-icon" sizes="76x76" href="$get_homepath(True)/static/common/icons/apple-touch-icon-76x76.png">
+<link rel="apple-touch-icon" sizes="152x152" href="$get_homepath(True)/static/common/icons/apple-touch-icon-152x152.png">
+<link rel="icon" type="image/png" href="$get_homepath(True)/static/common/icons/favicon-196x196.png" sizes="196x196">
+<link rel="icon" type="image/png" href="$get_homepath(True)/static/common/icons/favicon-160x160.png" sizes="160x160">
+<link rel="icon" type="image/png" href="$get_homepath(True)/static/common/icons/favicon-96x96.png" sizes="96x96">
+<link rel="icon" type="image/png" href="$get_homepath(True)/static/common/icons/favicon-16x16.png" sizes="16x16">
+<link rel="icon" type="image/png" href="$get_homepath(True)/static/common/icons/favicon-32x32.png" sizes="32x32">
 <meta name="msapplication-TileColor" content="#00a300">
-<meta name="msapplication-TileImage" content="$get_homepath()/static/common/icons/mstile-144x144.png">
-<meta name="msapplication-config" content="$get_homepath()/static/common/icons/browserconfig.xml">
+<meta name="msapplication-TileImage" content="$get_homepath(True)/static/common/icons/mstile-144x144.png">
+<meta name="msapplication-config" content="$get_homepath(True)/static/common/icons/browserconfig.xml">
 
 $if use_minified:
-    <script src="$get_homepath()/static/webapp/js/all-minified.js"></script>
+    <script src="$get_homepath(True)/static/webapp/js/all-minified.js"></script>
 $else:
-    <script src="$get_homepath()/static/common/js/libs/jquery.min.js" type="text/javascript" charset="utf-8"></script>
-    <script src="$get_homepath()/static/common/js/libs/jquery.form.min.js" type="text/javascript" charset="utf-8"></script>
-    <script src="$get_homepath()/static/common/js/codemirror/codemirror.js" type="text/javascript" charset="utf-8"></script>
-    <script src="$get_homepath()/static/common/js/codemirror/mode/meta.js" type="text/javascript" charset="utf-8"></script>
-    <script src="$get_homepath()/static/common/js/libs/bootstrap.min.js" type="text/javascript" charset="utf-8"></script>
-    <script src="$get_homepath()/static/common/js/libs/bootstrap-datetimepicker.min.js" type="text/javascript" charset="utf-8"></script>
-    <script src="$get_homepath()/static/common/js/libs/checked-list-group.js" type="text/javascript" charset="utf-8"></script>
-    <script src="$get_homepath()/static/common/js/common.js" type="text/javascript" charset="utf-8"></script>
-    <script src="$get_homepath()/static/common/js/task.js" type="text/javascript" charset="utf-8"></script>
-    <script src="$get_homepath()/static/webapp/js/webapp.js" type="text/javascript" charset="utf-8"></script>
-    <script src="$get_homepath()/static/webapp/js/studio.js" type="text/javascript" charset="utf-8"></script>
-    <script src="$get_homepath()/static/webapp/js/aggregations.js" type="text/javascript" charset="utf-8"></script>
-    <script src='$get_homepath()/static/webapp/js/jquery-sortable.min.js' type="text/javascript" charset="utf-8"></script>
+    <script src="$get_homepath(True)/static/common/js/libs/jquery.min.js" type="text/javascript" charset="utf-8"></script>
+    <script src="$get_homepath(True)/static/common/js/libs/jquery.form.min.js" type="text/javascript" charset="utf-8"></script>
+    <script src="$get_homepath(True)/static/common/js/codemirror/codemirror.js" type="text/javascript" charset="utf-8"></script>
+    <script src="$get_homepath(True)/static/common/js/codemirror/mode/meta.js" type="text/javascript" charset="utf-8"></script>
+    <script src="$get_homepath(True)/static/common/js/libs/bootstrap.min.js" type="text/javascript" charset="utf-8"></script>
+    <script src="$get_homepath(True)/static/common/js/libs/bootstrap-datetimepicker.min.js" type="text/javascript" charset="utf-8"></script>
+    <script src="$get_homepath(True)/static/common/js/libs/checked-list-group.js" type="text/javascript" charset="utf-8"></script>
+    <script src="$get_homepath(True)/static/common/js/common.js" type="text/javascript" charset="utf-8"></script>
+    <script src="$get_homepath(True)/static/common/js/task.js" type="text/javascript" charset="utf-8"></script>
+    <script src="$get_homepath(True)/static/webapp/js/webapp.js" type="text/javascript" charset="utf-8"></script>
+    <script src="$get_homepath(True)/static/webapp/js/studio.js" type="text/javascript" charset="utf-8"></script>
+    <script src="$get_homepath(True)/static/webapp/js/aggregations.js" type="text/javascript" charset="utf-8"></script>
+    <script src='$get_homepath(True)/static/webapp/js/jquery-sortable.min.js' type="text/javascript" charset="utf-8"></script>
 
 <script type="text/javascript">
-    CodeMirror.modeURL = "$get_homepath()/static/common/js/codemirror/mode/%N/%N.js";
+    CodeMirror.modeURL = "$get_homepath(True)/static/common/js/codemirror/mode/%N/%N.js";
 </script>
 
 $if "header" in content:
@@ -90,7 +90,7 @@ $:template_helper.call('header_hook')
                             class="icon-bar"></span> <span class="icon-bar"></span> <span
                             class="icon-bar"></span>
                     </button>
-                    <a class="navbar-brand" href="$get_homepath()/index"><img src="$get_homepath()/static/common/images/header.png" alt="logo"/> INGInious</a>
+                    <a class="navbar-brand" href="$get_homepath()/index"><img src="$get_homepath(True)/static/common/images/header.png" alt="logo"/> INGInious</a>
                 </div>
                 <div class="collapse navbar-collapse">
                     $if "Navbar" in content:

--- a/inginious/frontend/webapp/templates/maintenance.html
+++ b/inginious/frontend/webapp/templates/maintenance.html
@@ -10,47 +10,47 @@ $#
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="INGInious">
     <meta name="author" content="">
-    <link rel="icon" href="$get_homepath()/static/common/icons/favicon.ico">
-    <link rel="mask-icon" href="$get_homepath()/static/common/icons/wb.svg" color="#5E932E">
+    <link rel="icon" href="$get_homepath(True)/static/common/icons/favicon.ico">
+    <link rel="mask-icon" href="$get_homepath(True)/static/common/icons/wb.svg" color="#5E932E">
 
     <title>INGInious - maintenance in progress</title>
 
     <!-- Bootstrap -->
-    <link href="$get_homepath()/static/common/css/bootstrap.min.css" rel="stylesheet">
-    <link href="$get_homepath()/static/common/css/bootstrap-datetimepicker.min.css" rel="stylesheet">
+    <link href="$get_homepath(True)/static/common/css/bootstrap.min.css" rel="stylesheet">
+    <link href="$get_homepath(True)/static/common/css/bootstrap-datetimepicker.min.css" rel="stylesheet">
 
     <!-- INGInious Style -->
-    <link href="$get_homepath()/static/webapp/css/INGInious.css" rel="stylesheet">
+    <link href="$get_homepath(True)/static/webapp/css/INGInious.css" rel="stylesheet">
 
     <!-- Codemirror Style -->
-    <link href="$get_homepath()/static/common/css/codemirror.css" rel="stylesheet">
+    <link href="$get_homepath(True)/static/common/css/codemirror.css" rel="stylesheet">
 
     <!-- JQuery -->
 $if use_minified:
-    <script src="$get_homepath()/static/webapp/js/all-minified.js"></script>
+    <script src="$get_homepath(True)/static/webapp/js/all-minified.js"></script>
 $else:
-    <script src="$get_homepath()/static/common/js/libs/jquery.min.js" type="text/javascript" charset="utf-8"></script>
-    <script src="$get_homepath()/static/common/js/libs/jquery.form.min.js" type="text/javascript" charset="utf-8"></script>
-    <script src="$get_homepath()/static/common/js/common.js" type="text/javascript" charset="utf-8"></script>
+    <script src="$get_homepath(True)/static/common/js/libs/jquery.min.js" type="text/javascript" charset="utf-8"></script>
+    <script src="$get_homepath(True)/static/common/js/libs/jquery.form.min.js" type="text/javascript" charset="utf-8"></script>
+    <script src="$get_homepath(True)/static/common/js/common.js" type="text/javascript" charset="utf-8"></script>
 
     <!-- Icons -->
-    <link rel="shortcut icon" href="$get_homepath()/static/common/icons/favicon.ico">
-    <link rel="apple-touch-icon" sizes="57x57" href="$get_homepath()/static/common/icons/apple-touch-icon-57x57.png">
-    <link rel="apple-touch-icon" sizes="114x114" href="$get_homepath()/static/common/icons/apple-touch-icon-114x114.png">
-    <link rel="apple-touch-icon" sizes="72x72" href="$get_homepath()/static/common/icons/apple-touch-icon-72x72.png">
-    <link rel="apple-touch-icon" sizes="144x144" href="$get_homepath()/static/common/icons/apple-touch-icon-144x144.png">
-    <link rel="apple-touch-icon" sizes="60x60" href="$get_homepath()/static/common/icons/apple-touch-icon-60x60.png">
-    <link rel="apple-touch-icon" sizes="120x120" href="$get_homepath()/static/common/icons/apple-touch-icon-120x120.png">
-    <link rel="apple-touch-icon" sizes="76x76" href="$get_homepath()/static/common/icons/apple-touch-icon-76x76.png">
-    <link rel="apple-touch-icon" sizes="152x152" href="$get_homepath()/static/common/icons/apple-touch-icon-152x152.png">
-    <link rel="icon" type="image/png" href="$get_homepath()/static/common/icons/favicon-196x196.png" sizes="196x196">
-    <link rel="icon" type="image/png" href="$get_homepath()/static/common/icons/favicon-160x160.png" sizes="160x160">
-    <link rel="icon" type="image/png" href="$get_homepath()/static/common/icons/favicon-96x96.png" sizes="96x96">
-    <link rel="icon" type="image/png" href="$get_homepath()/static/common/icons/favicon-16x16.png" sizes="16x16">
-    <link rel="icon" type="image/png" href="$get_homepath()/static/common/icons/favicon-32x32.png" sizes="32x32">
+    <link rel="shortcut icon" href="$get_homepath(True)/static/common/icons/favicon.ico">
+    <link rel="apple-touch-icon" sizes="57x57" href="$get_homepath(True)/static/common/icons/apple-touch-icon-57x57.png">
+    <link rel="apple-touch-icon" sizes="114x114" href="$get_homepath(True)/static/common/icons/apple-touch-icon-114x114.png">
+    <link rel="apple-touch-icon" sizes="72x72" href="$get_homepath(True)/static/common/icons/apple-touch-icon-72x72.png">
+    <link rel="apple-touch-icon" sizes="144x144" href="$get_homepath(True)/static/common/icons/apple-touch-icon-144x144.png">
+    <link rel="apple-touch-icon" sizes="60x60" href="$get_homepath(True)/static/common/icons/apple-touch-icon-60x60.png">
+    <link rel="apple-touch-icon" sizes="120x120" href="$get_homepath(True)/static/common/icons/apple-touch-icon-120x120.png">
+    <link rel="apple-touch-icon" sizes="76x76" href="$get_homepath(True)/static/common/icons/apple-touch-icon-76x76.png">
+    <link rel="apple-touch-icon" sizes="152x152" href="$get_homepath(True)/static/common/icons/apple-touch-icon-152x152.png">
+    <link rel="icon" type="image/png" href="$get_homepath(True)/static/common/icons/favicon-196x196.png" sizes="196x196">
+    <link rel="icon" type="image/png" href="$get_homepath(True)/static/common/icons/favicon-160x160.png" sizes="160x160">
+    <link rel="icon" type="image/png" href="$get_homepath(True)/static/common/icons/favicon-96x96.png" sizes="96x96">
+    <link rel="icon" type="image/png" href="$get_homepath(True)/static/common/icons/favicon-16x16.png" sizes="16x16">
+    <link rel="icon" type="image/png" href="$get_homepath(True)/static/common/icons/favicon-32x32.png" sizes="32x32">
     <meta name="msapplication-TileColor" content="#00a300">
-    <meta name="msapplication-TileImage" content="$get_homepath()/static/common/icons/mstile-144x144.png">
-    <meta name="msapplication-config" content="$get_homepath()/static/common/icons/browserconfig.xml">
+    <meta name="msapplication-TileImage" content="$get_homepath(True)/static/common/icons/mstile-144x144.png">
+    <meta name="msapplication-config" content="$get_homepath(True)/static/common/icons/browserconfig.xml">
 </head>
 
 <body role="document">
@@ -64,7 +64,7 @@ $else:
                             class="icon-bar"></span> <span class="icon-bar"></span> <span
                             class="icon-bar"></span>
                     </button>
-                    <a class="navbar-brand" href="$get_homepath()/index"><img src="$get_homepath()/static/common/images/header.png" alt="logo"/> INGInious</a>
+                    <a class="navbar-brand" href="$get_homepath()/index"><img src="$get_homepath(True)/static/common/images/header.png" alt="logo"/> INGInious</a>
                 </div>
                 <div class="collapse navbar-collapse">
 
@@ -74,7 +74,7 @@ $else:
 
         <div class="container-fluid" role="main">
             <div id="content" class="col-xs-12">
-                <img src="$get_homepath()/static/common/images/logo_maintenance.png" style="margin:auto; display:block;"/>
+                <img src="$get_homepath(True)/static/common/images/logo_maintenance.png" style="margin:auto; display:block;"/>
                 <div class="alert alert-danger" role="alert" style="text-align: center;">
                     <b>This INGInious instance is currently under maintenance.</b> Please come back in a few minutes!
                 </div>

--- a/inginious/frontend/webapp/templates/notfound.html
+++ b/inginious/frontend/webapp/templates/notfound.html
@@ -8,7 +8,7 @@ $#
 $var title: Error 404
 
 $# Start content
-<img src="$get_homepath()/static/common/images/logo_maintenance.png" style="margin:auto; display:block;"/>
+<img src="$get_homepath(True)/static/common/images/logo_maintenance.png" style="margin:auto; display:block;"/>
 <div class="alert alert-danger" role="alert" style="text-align: center;">
     <b>Error 404</b> $:message
 </div>

--- a/inginious/frontend/webapp/templates/task_unavailable.html
+++ b/inginious/frontend/webapp/templates/task_unavailable.html
@@ -6,7 +6,7 @@ $#
 $var title: Task unavailable
 
 $# Start content
-<img src="$get_homepath()/static/common/images/logo_maintenance.png" style="margin:auto; display:block;"/>
+<img src="$get_homepath(True)/static/common/images/logo_maintenance.png" style="margin:auto; display:block;"/>
 <div class="alert alert-warning" role="alert" style="text-align: center;">
     <b>Error 403</b> Task unavailable
 </div>


### PR DESCRIPTION
To create a cookieless session, prefix the url with `/@@` (`http://www.instance.be/@@/index` for example).
Each page everywhere in the app will then be prefixed with the session_id, in the form `/@session_id@`.

This is completely transparent from the app point of view, everything is handled by the web.py Application class and its associated Session object.