### PR TITLE
Fix - After reset password error redirect

### DIFF
--- a/inginious/frontend/webapp/plugins/auth/db_auth/__init__.py
+++ b/inginious/frontend/webapp/plugins/auth/db_auth/__init__.py
@@ -240,6 +240,7 @@ Someone (probably you) asked to reset your INGInious password. If this was you, 
         elif "lostpasswd" in data:
             msg, error = self.lost_passwd(data)
         elif "resetpasswd" in data:
+            _, _, reset = self.get_reset_data(data)
             msg, error = self.reset_passwd(data)
 
         return self.template_helper.get_custom_renderer('frontend/webapp/plugins/auth/db_auth').register(reset, msg, error)


### PR DESCRIPTION
Fix - After reset password error, the page redirects to the reset page instead of staying in the enter new password page.