### PR TITLE
Tags in task_edit.py can be None, set to empty dict to avoid exception.

### DIFF
--- a/inginious/frontend/pages/course_admin/task_edit.py
+++ b/inginious/frontend/pages/course_admin/task_edit.py
@@ -209,6 +209,8 @@ class CourseEditTask(INGIniousAdminPage):
             
             #Tags
             tags = self.dict_from_prefix("tags", data)
+            if tags is None:
+                tags = {}
             tags = OrderedDict(sorted(tags.items(), key=lambda item: item[0])) # Sort by key
             
             # Repair tags


### PR DESCRIPTION
I encountered the following error when trying out the current version, when attempting to edit one of the tasks in the tutorial, after clicking "Save changes":

> Your browser returned an invalid form ('NoneType' object has no attribute 'items')

I traced it to the `tags` that were being returned via the `dict_from_prefix` method ("task_edit.py" line 211) -- it is possible that this method can return a `None`, and that seemed to be happening in my case.  This PR adds a test for `None` and sets the `tags` dict to the empty dict if it is `None`.
