### PR TITLE
Fix web.py cookies

### DIFF
--- a/inginious/frontend/app.py
+++ b/inginious/frontend/app.py
@@ -9,6 +9,9 @@ import gettext
 
 import inginious.frontend.pages.course_admin.utils as course_admin_utils
 import web
+from inginious.frontend.fix_webpy_cookies import fix_webpy_cookies
+fix_webpy_cookies() # TODO: remove me once https://github.com/webpy/webpy/pull/419 is merge in web.py
+
 from gridfs import GridFS
 from inginious.frontend.arch_helper import create_arch, start_asyncio_and_zmq
 from inginious.frontend.cookieless_app import CookieLessCompatibleApplication

--- a/inginious/frontend/fix_webpy_cookies.py
+++ b/inginious/frontend/fix_webpy_cookies.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INGInious. See the LICENSE and the COPYRIGHTS files for
+# more information about the licensing of this file.
+from collections import namedtuple
+import web
+
+from http.cookies import SimpleCookie, CookieError
+
+def fix_webpy_cookies():
+    """
+    Fixes a bug in web.py. See #208. PR is waiting to be merged upstream at https://github.com/webpy/webpy/pull/419
+    TODO: remove me once PR is merged upstream.
+    """
+
+    try:
+        web.webapi.parse_cookies('a="test"')  # make the bug occur
+    except NameError:
+        # monkeypatch web.py
+        SimpleCookie.iteritems = SimpleCookie.items
+        web.webapi.Cookie = namedtuple('Cookie', ['SimpleCookie', 'CookieError'])(SimpleCookie, CookieError)
+
+    web.webapi.parse_cookies('a="test"')  # check if it's ok
+
+
+if __name__ == '__main__':
+    fix_webpy_cookies()


### PR DESCRIPTION
Monkey-patch web.py to support correctly Py3, without having to fork or wait for the (critical) bug to be solved. Fixes #208. Fixes #257.