### PR TITLE
Hard coding default task (Issue 331 "Create task.yaml file directly after clicking on create task")

### DIFF
--- a/inginious/frontend/pages/course_admin/task_edit.py
+++ b/inginious/frontend/pages/course_admin/task_edit.py
@@ -40,7 +40,39 @@ class CourseEditTask(INGIniousAdminPage):
         except:
             task_data = None
         if task_data is None:
-            task_data = {}
+            # Default task
+            data = OrderedDict([
+                ('accessible', True), 
+                ('author', ''), 
+                ('context', ''), 
+                ('environment', 'mcq'), 
+                ('evaluate', 'best'), 
+                ('groups', False), 
+                ('input_random', '0'), 
+                ('limits', OrderedDict([
+                    ('output', '2'), 
+                    ('memory', '100'), 
+                    ('time', '30')
+                ])), 
+                ('name', 'default'), 
+                ('network_grading', False), 
+                ('problems', OrderedDict([
+                    ('default', OrderedDict([
+                        ('type', 'file'), 
+                        ('header', ''), 
+                        ('name', 'default')
+                    ]))
+                ])), 
+                ('stored_submissions', 0), 
+                ('submission_limit', OrderedDict([
+                    ('amount', -1), 
+                    ('period', -1)
+                ])), 
+                ('tags', OrderedDict()), 
+                ('weight', 1.0)
+            ])
+            self.task_factory.update_task_descriptor_content(courseid, taskid, data, force_extension="yaml")
+            task_data = self.task_factory.get_task_descriptor_content(courseid, taskid)
 
         environments = self.containers
 


### PR DESCRIPTION
#331 @anthonygego 
I write this branch as an example of creating directly the task.yaml file after clicking on create task. In this example a default configuration of the task.yaml file is hard coded in the source, this could be change to use a file instead of a hard coded configuration but i cannot think where to put this configuration file.

Also to illustrate the problem of just adding the file directly:
- The user doesn't know that the task has already been created. (In the case he decides to cancel the task creation or close the browser in the half of the process).
- Create a configuration file or add some configuration to the database has "bad smell".

This is why I want to add a default field in the entries on the database like in the "create classroom section". And to show the creation of the file I want to remove the redirection to the "edit task section".

![](https://thumbs.gfycat.com/FineUnsightlyBeaver-max-14mb.gif)