### PR TITLE
Fixes #338

### DIFF
--- a/inginious/frontend/static/js/task.js
+++ b/inginious/frontend/static/js/task.js
@@ -622,7 +622,7 @@ function load_feedback_match(key, content) {
     load_feedback_code(key, content);
 }
 
-function load_feedback_single_line_code(key, content) {
+function load_feedback_code_single_line(key, content) {
     load_feedback_code(key, content);
 }
 

--- a/inginious/frontend/task_problems.py
+++ b/inginious/frontend/task_problems.py
@@ -96,7 +96,7 @@ class DisplayableCodeSingleLineProblem(CodeSingleLineProblem, DisplayableProblem
         header = ParsableText(self.gettext(language, self._header), "rst",
                               translation=self._translations.get(language, gettext.NullTranslations()))
         return str(DisplayableCodeSingleLineProblem.get_renderer(template_helper)
-                   .tasks.single_line_code(self.get_id(), header, "text", 0, self._optional, self._default))
+                   .tasks.code_single_line(self.get_id(), header, "text", 0, self._optional, self._default))
 
     @classmethod
     def show_editbox(cls, template_helper, key):


### PR DESCRIPTION
Solves bug where the input fields would still be grayed out after the
end of the running task if the answer to a single-line code is
incorrect.