### PR TITLE
Add explicit encoding to long_description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,5 +80,5 @@ setup(
     author_email="inginious@info.ucl.ac.be",
     license="AGPL 3",
     url="https://github.com/UCL-INGI/INGInious",
-    long_description=open(os.path.join(os.path.dirname(__file__), 'README.rst')).read()
+    long_description=open(os.path.join(os.path.dirname(__file__), 'README.rst'), encoding='utf8').read()
 )


### PR DESCRIPTION
Without an explicit encoding, install via pip fails in environments where the default encoding is ASCII.