### PR TITLE
Fixes contains_is_html method for non-string keys

### DIFF
--- a/inginious/frontend/pages/course_admin/task_edit.py
+++ b/inginious/frontend/pages/course_admin/task_edit.py
@@ -73,7 +73,7 @@ class CourseEditTask(INGIniousAdminPage):
     def contains_is_html(cls, data):
         """ Detect if the problem has at least one "xyzIsHTML" key """
         for key, val in data.items():
-            if key.endswith("IsHTML"):
+            if isinstance(key, str) and key.endswith("IsHTML"):
                 return True
             if isinstance(val, (OrderedDict, dict)) and cls.contains_is_html(val):
                 return True


### PR DESCRIPTION
A YAML task description can also contains integer keys, which will be parsed as such by the YAML parser. The fix prevents an error from being raised and returns the correct value.