### PR TITLE
Make the webdav a standalone app

### DIFF
--- a/doc/commands.rst
+++ b/doc/commands.rst
@@ -9,6 +9,7 @@ Frontend commands
 
     commands_doc/inginious-install
     commands_doc/inginious-webapp
+    commands_doc/inginious-webdav
 
 Backend commands
 ----------------

--- a/doc/commands_doc/inginious-webdav.rst
+++ b/doc/commands_doc/inginious-webdav.rst
@@ -1,16 +1,16 @@
 .. _inginious-webapp:
 
-inginious-webapp
+inginious-webdav
 ================
 
 Start the Web App Frontend. This command can run a standalone web server (see ``--host`` and ``--port`` options),
 but also as a FastCGI or WSGI backend.
 
-.. program:: inginious-webapp
+.. program:: inginious-webdav
 
 ::
 
-    inginious-webapp [-h] [--config CONFIG] [--host HOST] [--port PORT]
+    inginious-webdav [-h] [--config CONFIG] [--host HOST] [--port PORT]
 
 .. option:: --config
 
@@ -20,12 +20,12 @@ but also as a FastCGI or WSGI backend.
 .. option:: --host HOST
 
    Specify the host to which to bind to. By default, it is localhost.
-   This can also be specified via the ``INGINIOUS_WEBAPP_HOST`` environment variable.
+   This can also be specified via the ``INGINIOUS_WEBDAV_HOST`` environment variable.
 
 .. option:: --port PORT
 
    Specify the port to which to bind to. By default, it is 8080.
-   This can also be specified via the ``INGINIOUS_WEBAPP_PORT`` environment variable.
+   This can also be specified via the ``INGINIOUS_WEBDAV_PORT`` environment variable.
 
 .. option:: -h, --help
 

--- a/doc/install_doc/config_reference.rst
+++ b/doc/install_doc/config_reference.rst
@@ -116,6 +116,11 @@ The different entries are :
     If set, it allows to use in-browser task debug via ssh. (See :ref:`_webterm_setup` for
     more information)
 
+``webdav_host``
+   Link to the INGInious webdav app with the following syntax: ``http[s]://host:port``.
+   If set, a new page displays a WebDAV URL and login/password for administrators to access
+   the course filesystem.
+
 .. _configuration.example.yaml: https://github.com/UCL-INGI/INGInious/blob/master/configuration.example.yaml
 .. _docker-py API: https://github.com/docker/docker-py/blob/master/docs/api.md#client-api
 

--- a/inginious-webdav
+++ b/inginious-webdav
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# This file is part of INGInious. See the LICENSE and the COPYRIGHTS files for
+# more information about the licensing of this file.
+
+import os
+import sys
+import argparse
+import logging
+import web
+
+from inginious.common.log import init_logging, CustomLogMiddleware
+from inginious.common.base import load_json_or_yaml
+import inginious.frontend.webdav
+
+# Apache wsgi module only set env vars when a request is done
+os.environ['INGINIOUS_WEBAPP_CONFIG'] = os.environ.get("INGINIOUS_WEBAPP_CONFIG", "")
+os.environ['INGINIOUS_WEBDAV_HOST'] = os.environ.get("INGINIOUS_WEBDAV_HOST", "localhost")
+os.environ['INGINIOUS_WEBDAV_PORT'] = os.environ.get("INGINIOUS_WEBDAV_PORT", "8080")
+
+# If INGInious files are not installed in Python path
+sys.path.append(os.path.dirname(__file__))
+
+if __name__ == "__main__":
+    # Parse the paramaters from command line arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config",
+                        help="Path to configuration file. By default: configuration.yaml or configuration.json", default=os.environ["INGINIOUS_WEBAPP_CONFIG"])
+    parser.add_argument("--host", help="Host to bind to. Default is localhost.", default=os.environ["INGINIOUS_WEBDAV_HOST"])
+    parser.add_argument("--port", help="Port to listen to. Default is 8080.", type=int, default=os.environ["INGINIOUS_WEBDAV_PORT"])
+    args = parser.parse_args()
+
+    host = args.host
+    port = args.port
+    configfile = args.config
+else:
+    # Parse the parameters from environment variables
+    host = os.environ["INGINIOUS_WEBDAV_HOST"]
+    port = os.environ["INGINIOUS_WEBDAV_PORT"]
+    configfile = os.environ["INGINIOUS_WEBAPP_CONFIG"]
+
+if not configfile:
+    if os.path.isfile("./configuration.yaml"):
+        configfile = "./configuration.yaml"
+    elif os.path.isfile("./configuration.json"):
+        configfile = "./configuration.json"
+    else:
+        raise Exception("No configuration file found")
+
+# Load configuration and application (!!! For mod_wsgi, application identifier must be present)
+config = load_json_or_yaml(configfile)
+application = inginious.frontend.webdav.get_app(config)
+
+# Init logging
+init_logging(config.get('log_level', 'INFO'))
+logging.getLogger("inginious.webdav").info("http://%s:%d/" % (host, int(port)))
+
+if 'SERVER_SOFTWARE' in os.environ:  # cgi
+    os.environ['FCGI_FORCE_CGI'] = 'Y'
+
+if 'PHP_FCGI_CHILDREN' in os.environ or 'SERVER_SOFTWARE' in os.environ:  # lighttpd fastcgi
+    import flup.server.fcgi as flups
+    flups.WSGIServer(application, multiplexed=True, bindAddress=None, debug=False).run()
+
+# Launch the integrated websever if app launched in cmd line
+if __name__ == "__main__":
+    # Add static redirection and request log
+    application = CustomLogMiddleware(application, logging.getLogger("inginious.webdav.requests"))
+
+    # Launch the app
+    server = web.httpserver.WSGIServer((host, int(port)), application)
+    try:
+        server.start()
+    except KeyboardInterrupt:
+        server.stop()
+

--- a/inginious/frontend/app.py
+++ b/inginious/frontend/app.py
@@ -240,16 +240,6 @@ def get_app(config):
     if config.get('log_level', 'INFO') == 'DEBUG':
         appli.internalerror = debugerror
 
-    # Init webdav if possible (for now, only available with LocalFSProvider)
-    if isinstance(fs_provider, LocalFSProvider):
-        from inginious.frontend.webdav import WebDavProxy, init_webdav
-        webdav_available = True
-        webdav = init_webdav(user_manager, course_factory, task_factory)
-        appli_wsgi = lambda: WebDavProxy(appli.wsgifunc(), webdav)
-    else:
-        webdav_available = False
-        appli_wsgi = lambda: appli.wsgifunc()
-
     # Insert the needed singletons into the application, to allow pages to call them
     appli.plugin_manager = plugin_manager
     appli.course_factory = course_factory
@@ -269,7 +259,7 @@ def get_app(config):
     appli.available_languages = available_languages
     appli.welcome_page = config.get("welcome_page", None)
     appli.static_directory = config.get("static_directory", "./static")
-    appli.webdav_available = webdav_available
+    appli.webdav_host = config.get("webdav_host", None)
 
     # Init the mapping of the app
     appli.init_mapping(urls)
@@ -280,4 +270,4 @@ def get_app(config):
     # Start the inginious.backend
     client.start()
 
-    return appli_wsgi(), lambda: _close_app(appli, mongo_client, client)
+    return appli.wsgifunc(), lambda: _close_app(appli, mongo_client, client)

--- a/inginious/frontend/pages/course_admin/utils.py
+++ b/inginious/frontend/pages/course_admin/utils.py
@@ -266,7 +266,7 @@ def get_menu(course, current, renderer, plugin_manager, user_manager):
                         ("download", "<i class='fa fa-download fa-fw'></i>&nbsp; " + _("Download submissions"))]
 
     if user_manager.has_admin_rights_on_course(course):
-        if web.ctx.app_stack[0].webdav_available:
+        if web.ctx.app_stack[0].webdav_host:
             default_entries += [("webdav", "<i class='fa fa-folder-open fa-fw'></i>&nbsp; " + _("WebDAV access"))]
         default_entries += [("replay", "<i class='fa fa-refresh fa-fw'></i>&nbsp; " + _("Replay submissions")),
                             ("danger", "<i class='fa fa-bomb fa-fw'></i>&nbsp; " + _("Danger zone"))]

--- a/inginious/frontend/pages/course_admin/webdav.py
+++ b/inginious/frontend/pages/course_admin/webdav.py
@@ -18,10 +18,10 @@ class WebDavInfoPage(INGIniousAdminPage):
 
     def page(self, course):
         """ Get all data and display the page """
-        if not self.webdav_available:
+        if not self.webdav_host:
             raise web.notfound()
 
-        url = web.ctx.home + "/dav/"+course.get_id()
+        url = self.webdav_host + "/" + course.get_id()
         username = self.user_manager.session_username()
         apikey = self.user_manager.session_api_key()
         return self.template_helper.get_renderer().course_admin.webdav(course, url, username, apikey)

--- a/inginious/frontend/pages/utils.py
+++ b/inginious/frontend/pages/utils.py
@@ -111,9 +111,9 @@ class INGIniousPage(object):
         return self.app.lti_outcome_manager
 
     @property
-    def webdav_available(self) -> bool:
+    def webdav_host(self) -> str:
         """ True if webdav is available """
-        return self.app.webdav_available
+        return self.app.webdav_host
 
     @property
     def logger(self) -> logging.Logger:

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
         'inginious-agent-mcq',
         'inginious-backend',
         'inginious-webapp',
+        'inginious-webdav',
         'inginious-install',
         'utils/sync/inginious-synchronize',
         'utils/container_update/inginious-container-update',


### PR DESCRIPTION
Quick changes to allow clients to ask OPTIONS/PROPFIND on ``/``.

``inginious-webdav`` is quite similar to ``inginious-webapp``. Maybe they can even be merged actually.

``webdav_available`` is replaced by the use of ``webdav_host`` set in ``configuration.yaml``.