### PR TITLE
Stop raising exception when task is deleted but it is not saved yet

### DIFF
--- a/inginious/common/task_factory.py
+++ b/inginious/common/task_factory.py
@@ -280,12 +280,9 @@ class TaskFactory(object):
 
         task_fs = self.get_task_fs(courseid, taskid)
 
-        if not task_fs.exists():
-            raise TaskNotFoundException()
-
-        task_fs.delete()
-
-        get_course_logger(courseid).info("Task %s erased from the factory.", taskid)
+        if task_fs.exists():
+            task_fs.delete()
+            get_course_logger(courseid).info("Task %s erased from the factory.", taskid)
 
     def get_problem_types(self):
         """


### PR DESCRIPTION
When a task is created and the next step you do is delete it, it raises an exception because the task does not exist. This can be recreated as follows:
1. Create a task:
![image](https://user-images.githubusercontent.com/22863695/49044573-3c14fa00-f19c-11e8-9513-fcfd71107a5c.png)

2. Proceed to delete the just created task (don't save it): 
![image](https://user-images.githubusercontent.com/22863695/49044609-5353e780-f19c-11e8-997c-de36a07c01da.png)

3. The following page is shown as result of this:
![image](https://user-images.githubusercontent.com/22863695/49044650-6b2b6b80-f19c-11e8-81a8-2f9888062b2c.png)

**An use case for this could be when an user by mistake creates a task and it just want to delete the task before saving it.**  

The proposed solution in this PR is: stop raising the Exception if the task does not exist and only delete it if it exists.
I think this is a good solution as we should only delete the task if and only if the task exists.
**Note**: If you have another solution for this, please LMK as we want to fix this ASAP.