### PR TITLE
Show a soft deadline for tasks

### DIFF
--- a/doc/teacher_doc/task_file.rst
+++ b/doc/teacher_doc/task_file.rst
@@ -56,6 +56,10 @@ subdirectory.
     ``"START/END"``
         where *START* and *END* are valid dates, like "2014-05-10 10:11:12", or
         "2014-06-18". The task is only accessible between *START* and *END*.
+    ``"START/SOFT_DEADLINE/END"``
+        where *START*, *SOFT_DEADLINE* and *END* are valid dates, like "2014-05-10 10:11:12",
+        or "2014-06-18". The task is only accessible between *START* and *END*, but the
+        publicly communicated end time is *SOFT_DEADLINE*.
 
 -   ``problems`` describes sub-problems of this task. This field is mandatory and must contain
     at least one problem. Problem types are described in the following section

--- a/inginious/frontend/pages/course_admin/task_edit.py
+++ b/inginious/frontend/pages/course_admin/task_edit.py
@@ -262,13 +262,14 @@ class CourseEditTask(INGIniousAdminPage):
 
             # Accessible
             if data["accessible"] == "custom":
-                data["accessible"] = "{}/{}".format(data["accessible_start"], data["accessible_end"])
+                data["accessible"] = "{}/{}/{}".format(data["accessible_start"], data["accessible_soft_end"], data["accessible_end"])
             elif data["accessible"] == "true":
                 data["accessible"] = True
             else:
                 data["accessible"] = False
             del data["accessible_start"]
             del data["accessible_end"]
+            del data["accessible_soft_end"]
 
             # Checkboxes
             if data.get("responseIsHTML"):

--- a/inginious/frontend/tasks.py
+++ b/inginious/frontend/tasks.py
@@ -81,7 +81,8 @@ class WebAppTask(Task):
         elif self.get_accessible_time().is_never_accessible():
             return _("It's too late")
         else:
-            return self.get_accessible_time().get_end_date().strftime("%d/%m/%Y %H:%M:%S")
+            # Prefer to show the soft deadline rather than the hard one
+            return self.get_accessible_time().get_soft_end_date().strftime("%d/%m/%Y %H:%M:%S")
 
     def is_group_task(self):
         """ Indicates if the task submission mode is per groups """

--- a/inginious/frontend/templates/course_admin/edit_tabs/basic.html
+++ b/inginious/frontend/templates/course_admin/edit_tabs/basic.html
@@ -194,10 +194,29 @@ $else:
                 </div>
             </div>
         </div>
+        <div class="row">
+            <!-- Padding -->
+            <div class="col-xs-12 col-lg-3"></div>
+            <div class="col-xs-offset-1 col-lg-offset-0 col-xs-11 col-lg-4"></div>
+            <!-- End of padding -->
+            <div class="col-xs-offset-1 col-lg-offset-0 col-xs-11 col-lg-1"><label class="control-label">$:_("Soft Deadline")</label></div>
+            <div class="col-xs-offset-1 col-lg-offset-0 col-xs-11 col-lg-4">
+                <div class="form-group">
+                    <div class='input-group date' id='accessible_soft_end_picker' data-target-input="nearest">
+                            <input data-target='#accessible_soft_end_picker' name="accessible_soft_end" data-date-format="YYYY-MM-DD HH:mm:ss" value="${at.get_std_soft_end_date()}" placeholder="2014-06-29 10:00" type='text' class="form-control datetimepicker-input" />
+                            <div class="input-group-append" data-target="#accessible_soft_end_picker" data-toggle="datetimepicker">
+                                    <div class="input-group-text"><i class="fa fa-calendar"></i></div>
+                            </div>
+
+                    </div>
+                </div>
+            </div>
+        </div>
         <script type="text/javascript">
             \$(function() {
                 \$('#accessible_start_picker').datetimepicker({locale: '$user_manager.session_language()', sideBySide: true, format:'YYYY-MM-DD HH:mm:ss'});
                 \$('#accessible_end_picker').datetimepicker({locale: '$user_manager.session_language()', sideBySide: true, format:'YYYY-MM-DD HH:mm:ss'});
+                \$('#accessible_soft_end_picker').datetimepicker({locale: '$user_manager.session_language()', sideBySide: true, format:'YYYY-MM-DD HH:mm:ss'});
             });
         </script>
     </div>

--- a/inginious/frontend/templates/task.html
+++ b/inginious/frontend/templates/task.html
@@ -19,12 +19,20 @@ $def ColumnF():
                 <td>$task.get_authors(user_manager.session_language())</td>
             </tr>
         $if not is_lti():
-            <tr>
-                <td>$:_("Deadline")</td>
-                <td>
-                    $task.get_deadline()
-                </td>
-            </tr>
+            $if task.get_accessible_time().is_open() and not task.get_accessible_time().is_open_with_soft_deadline():
+                <tr class="list-group-item-danger">
+                    <td>$:_("Deadline")</td>
+                    <td>
+                        $task.get_deadline()
+                    </td>
+                </tr>
+            $else:
+                <tr>
+                    <td>$:_("Deadline")</td>
+                    <td>
+                        $task.get_deadline()
+                    </td>
+                </tr>
         $if registered or staff:
             <tr>
                 <td>$:_("Status")</td>


### PR DESCRIPTION
Sometimes, students might be tempted to perform homeworks at the very
last moment, which can be too late. This commit implements a soft
deadline mechanism that is publicly communicated, and keep the previous
deadline as hard deadline, which is kept private but determines until
when the task is available.