### PR TITLE
Fix bug adding student to a course but username is empty

### DIFF
--- a/inginious/frontend/user_manager.py
+++ b/inginious/frontend/user_manager.py
@@ -642,6 +642,10 @@ class UserManager:
 
         user_info = self._database.users.find_one({"username":username})
 
+        # Do not continue registering the user in the course if username is empty.
+        if not username:
+            return False
+
         if not force:
             if not course.is_registration_possible(user_info):
                 return False


### PR DESCRIPTION
When you try to add a student to a course but if the username in the input is empty, an exception like this is shown:
![image](https://user-images.githubusercontent.com/22863695/49835109-37d80780-fd6c-11e8-8126-8745fe90749b.png)

The this happens when you are in **course administration** in **students** tab, the you try adding a student but the inserted username is empty.