### PR TITLE
Record late submissions

### DIFF
--- a/inginious/frontend/pages/tasks.py
+++ b/inginious/frontend/pages/tasks.py
@@ -355,6 +355,7 @@ class BaseTaskPage(object):
 
         tojson["text"] = "<b>" + tojson["text"] + " " + _("[Submission #{submissionid}]").format(submissionid=data["_id"]) + "</b>" + data.get("text", "")
         tojson["text"] = self.plugin_manager.call_hook_recursive("feedback_text", task=task, submission=data, text=tojson["text"])["text"]
+        tojson["late"] = data.get("late", False)
 
         if reloading:
             # Set status='ok' because we are reloading an old submission.

--- a/inginious/frontend/static/js/task.js
+++ b/inginious/frontend/static/js/task.js
@@ -116,6 +116,8 @@ function displayNewSubmission(id)
     }
 
     jQuery('<span id="txt"/>', {}).text(getDateTime()).appendTo(submission_link);
+    submission_link.append(" ");
+    jQuery('<i id="status"/>', {class: ""}).appendTo(submission_link);
     
     //If there exists tags, we add a badge with '0' in the new submission.
     if($('span', $('#main_tag_group')).length > 0){
@@ -141,7 +143,7 @@ function removeSubmission(id) {
 }
 
 //Updates a loading submission
-function updateSubmission(id, result, grade, tags)
+function updateSubmission(id, result, grade, tags, late)
 {
     grade = grade || "0.0";
 
@@ -156,7 +158,12 @@ function updateSubmission(id, result, grade, tags)
             $(this).removeClass('list-group-item-warning').addClass(nclass);
             var date = $(this).find("span[id='txt']");
             date.text(date.text() + " - " + grade + "%");
-            
+
+            if (late) {
+                var status = $(this).find("i[id='status']");
+                status.addClass("fa fa-clock-o");
+            }
+
             //update the badge
             updateTagsToNewSubmission($(this), tags);  
         }
@@ -418,10 +425,15 @@ function waitForSubmission(submissionid)
                     else // == "error"
                         displayTaskStudentAlertWithProblems(data, "danger", false);
 
+                    var late = false;
+                    if ("late" in data) {
+                        late = data["late"];
+                    }
+
                     if("tests" in data){
-                        updateSubmission(submissionid, data['result'], data["grade"], data["tests"]);
+                        updateSubmission(submissionid, data['result'], data["grade"], data["tests"], late);
                     }else{
-                        updateSubmission(submissionid, data['result'], data["grade"], []);
+                        updateSubmission(submissionid, data['result'], data["grade"], [], late);
                     }
                     unblurTaskForm();
 
@@ -434,7 +446,7 @@ function waitForSubmission(submissionid)
                 else
                 {
                     displayTaskStudentAlertWithProblems(data, "danger", false);
-                    updateSubmission(submissionid, "error", "0.0", []);
+                    updateSubmission(submissionid, "error", "0.0", [], false);
                     updateTaskStatus("Failed", 0);
                     unblurTaskForm();
                 }
@@ -443,7 +455,7 @@ function waitForSubmission(submissionid)
             .fail(function()
             {
                 displayTaskStudentAlertWithProblems(data, "danger", false);
-                updateSubmission(submissionid, "error", "0.0", []);
+                updateSubmission(submissionid, "error", "0.0", [], false);
                 updateTaskStatus("Failed", 0);
                 unblurTaskForm();
             });

--- a/inginious/frontend/submission_manager.py
+++ b/inginious/frontend/submission_manager.py
@@ -259,6 +259,8 @@ class WebAppSubmissionManager:
         accessible_time = task.get_accessible_time()
         is_late = accessible_time.is_open() and not accessible_time.is_open_with_soft_deadline()
         inputdata["@late"] = is_late
+        # We duplicate this in its own submission field to get this attribute at front-end
+        obj["late"] = is_late
 
         self._hook_manager.call_hook("new_submission", submission=obj, inputdata=inputdata)
         obj["input"] = self._gridfs.put(bson.BSON.encode(inputdata))

--- a/inginious/frontend/submission_manager.py
+++ b/inginious/frontend/submission_manager.py
@@ -255,6 +255,10 @@ class WebAppSubmissionManager:
         states = self._database.user_tasks.find_one({"courseid": task.get_course_id(), "taskid": task.get_id(), "username": username}, {"random": 1, "state": 1})
         inputdata["@random"] = states["random"] if "random" in states else []
         inputdata["@state"] = states["state"] if "state" in states else ""
+        # Record if the submission was late or not
+        accessible_time = task.get_accessible_time()
+        is_late = accessible_time.is_open() and not accessible_time.is_open_with_soft_deadline()
+        inputdata["@late"] = is_late
 
         self._hook_manager.call_hook("new_submission", submission=obj, inputdata=inputdata)
         obj["input"] = self._gridfs.put(bson.BSON.encode(inputdata))

--- a/inginious/frontend/templates/task.html
+++ b/inginious/frontend/templates/task.html
@@ -223,6 +223,11 @@ $def ColumnF():
                                 <span id="txt">$submission["submitted_on"].strftime("%d/%m/%Y %H:%M:%S") - $submission["grade"]%</span>
                             $else:
                                 <span id="txt">$submission["submitted_on"].strftime("%d/%m/%Y %H:%M:%S")</span>
+
+                            $if submission.get("late", False):
+                                <i id="status" class="fa fa-clock-o"></i>
+                            $else:
+                                <i id="status" class=""></i>
                         </li>
                         
                 $else:


### PR DESCRIPTION
This is done by adding a @late tag in the input of the submission.

This PR also shows the fact that submissions are late in the task submission list, but this requires adding its own field in the submission db. This is done by the second commit, that indicates it either at page load time (html) or at submission time (js + tasks.py files).