### PR TITLE
Redirect from logout to courselist

### DIFF
--- a/inginious/frontend/pages/utils.py
+++ b/inginious/frontend/pages/utils.py
@@ -188,11 +188,11 @@ class SignInPage(INGIniousAuthPage):
 class LogOutPage(INGIniousAuthPage):
     def GET_AUTH(self, *args, **kwargs):
         self.user_manager.disconnect_user()
-        raise web.seeother(web.ctx.env.get('HTTP_REFERER', '/'))
+        raise web.seeother("/courselist")
 
     def POST_AUTH(self, *args, **kwargs):
         self.user_manager.disconnect_user()
-        raise web.seeother(web.ctx.env.get('HTTP_REFERER', '/'))
+        raise web.seeother("/courselist")
 
 
 class INGIniousStaticPage(INGIniousPage):


### PR DESCRIPTION
Just a little tweak for preventing bad redirection on logout
![](https://thumbs.gfycat.com/MedicalSentimentalIceblueredtopzebra-size_restricted.gif)

Instead redirect to /courselist.