### PR TITLE
Typo in WebDav interface

### DIFF
--- a/inginious/frontend/i18n/en/LC_MESSAGES/messages.po
+++ b/inginious/frontend/i18n/en/LC_MESSAGES/messages.po
@@ -2608,7 +2608,7 @@ msgid "WebDAV"
 msgstr ""
 
 #: inginious/frontend/templates/course_admin/webdav.html:23
-msgid "Use this URL to access to your course folder using WebDav:"
+msgid "Use this URL to access your course folder using WebDav:"
 msgstr ""
 
 #: inginious/frontend/templates/course_admin/webdav.html:26

--- a/inginious/frontend/templates/course_admin/webdav.html
+++ b/inginious/frontend/templates/course_admin/webdav.html
@@ -22,7 +22,7 @@ $def NavbarF():
 $var Navbar: $:NavbarF()
 
 <h2>$:_("WebDAV access")</h2>
-$:_("Use this URL to access to your course folder using WebDav:")<br/>
+$:_("Use this URL to access your course folder using WebDav:")<br/>
 <br/>
 <table class="table">
     <tr><td>$:_("URL")</td><td><code>$url</code></td></tr>


### PR DESCRIPTION
Also, there's a missing translation in French, but I couldn't manage to edit the file correctly (bad encoding of the file leads to problems when using characters like 'é' or 'à').
(At least, I'm pretty sure this is a typo)