### PR TITLE
fix google_auth.py authentication error

### DIFF
--- a/inginious/frontend/plugins/auth/google_auth.py
+++ b/inginious/frontend/plugins/auth/google_auth.py
@@ -17,7 +17,8 @@ authorization_base_url = 'https://accounts.google.com/o/oauth2/v2/auth'
 token_url = 'https://www.googleapis.com/oauth2/v4/token'
 scope = [
     "https://www.googleapis.com/auth/userinfo.email",
-    "https://www.googleapis.com/auth/userinfo.profile"
+    "https://www.googleapis.com/auth/userinfo.profile",
+    "openid"
 ]
 
 class GoogleAuthMethod(AuthMethod):


### PR DESCRIPTION
In mid or late July, we started receiving errors indicating 
```
Scope has changed from "https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile" to "https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile openid"
```
This fix adds the openid as required by Google Sign-In ( https://developers.google.com/identity/protocols/googlescopes )

This resolves issue #408 