### PR TITLE
Job priority based scheduling

### DIFF
--- a/inginious-autotest
+++ b/inginious-autotest
@@ -131,7 +131,7 @@ def test_task(yaml_data, task, client, client_sync):
         time.sleep(1)
     if task.get_environment() not in client.get_available_containers():
         raise Exception('Environment not available')
-    new_output = client_sync.new_job(task, yaml_data['input'])  # request the client with input from yaml and given task
+    new_output = client_sync.new_job(0, task, yaml_data['input'])  # request the client with input from yaml and given task
     keys = ["result", "grade", "problems", "tests", "custom", "state", "archive", "stdout", "stderr"]
     old_output = [yaml_data.get(x, None) for x in keys]
     return compare_all_outputs(old_output, new_output, keys)

--- a/inginious/client/client.py
+++ b/inginious/client/client.py
@@ -250,9 +250,9 @@ class Client(BetterParanoidPirateClient):
         """
         return self._available_containers
 
-    def new_job(self, task, inputdata, callback, launcher_name="Unknown", debug=False, ssh_callback=None):
+    def new_job(self, priority, task, inputdata, callback, launcher_name="Unknown", debug=False, ssh_callback=None):
         """ Add a new job. Every callback will be called once and only once.
-
+        :param priority: Priority of the job
         :type task: Task
         :param inputdata: input from the student
         :type inputdata: Storage or dict
@@ -303,7 +303,7 @@ class Client(BetterParanoidPirateClient):
             callback(("crash", "Error while reading task limits"), 0.0, {}, {}, "", {}, None, "", "")
             return
 
-        msg = ClientNewJob(job_id, task.get_course_id(), task.get_id(), inputdata, environment, enable_network, time_limit,
+        msg = ClientNewJob(job_id, priority, task.get_course_id(), task.get_id(), inputdata, environment, enable_network, time_limit,
                            hard_time_limit, mem_limit, debug, launcher_name)
         self._loop.call_soon_threadsafe(asyncio.ensure_future, self._create_transaction(msg, task=task, callback=callback,
                                                                                         ssh_callback=ssh_callback))

--- a/inginious/client/client_buffer.py
+++ b/inginious/client/client_buffer.py
@@ -16,11 +16,11 @@ class ClientBuffer(object):
         self._waiting_jobs = []
         self._jobs_done = {}
 
-    def new_job(self, task, inputdata, launcher_name="Unknown", debug=False):
+    def new_job(self, priority, task, inputdata, launcher_name="Unknown", debug=False):
         """ Runs a new job. It works exactly like the Client class, instead that there is no callback """
         bjobid = uuid.uuid4()
         self._waiting_jobs.append(str(bjobid))
-        self._client.new_job(task, inputdata,
+        self._client.new_job(priority, task, inputdata,
                              (lambda result, grade, problems, tests, custom, archive, stdout, stderr:
                               self._callback(bjobid, result, grade, problems, tests, custom, archive, stdout, stderr)),
                              launcher_name, debug)

--- a/inginious/client/client_sync.py
+++ b/inginious/client/client_sync.py
@@ -13,7 +13,7 @@ class ClientSync(object):
     def __init__(self, client):
         self._client = client
 
-    def new_job(self, task, inputdata, launcher_name="Unknown", debug=False):
+    def new_job(self, priority, task, inputdata, launcher_name="Unknown", debug=False):
         """
             Runs a new job.
             It works exactly like the Client class, instead that there is no callback and directly returns result, in the form of a tuple
@@ -28,7 +28,7 @@ class ClientSync(object):
 
         manage_output.job_return = None
 
-        self._client.new_job(task, inputdata, manage_output, launcher_name, debug)
+        self._client.new_job(priority, task, inputdata, manage_output, launcher_name, debug)
         job_semaphore.acquire()
         job_return = manage_output.job_return
         return job_return

--- a/inginious/common/messages.py
+++ b/inginious/common/messages.py
@@ -37,12 +37,13 @@ class ClientNewJob(metaclass=MessageMeta, msgtype="client_new_job"):
         B->A.
     """
 
-    def __init__(self, job_id: ClientJobId,
+    def __init__(self, job_id: ClientJobId, priority: int,
                  course_id: str, task_id: str, inputdata: Dict[str, Any],
                  environment: str, enable_network: bool, time_limit: int, hard_time_limit: Optional[int], mem_limit: int,
                  debug: Union[str, bool], launcher: str):
         """
         :param job_id: the client-side job id that is associated to this job
+        :param priority: the job priority
         :param course_id: course id of the task to run
         :param task_id: task id of the task to run
         :param inputdata: student input data
@@ -58,6 +59,7 @@ class ClientNewJob(metaclass=MessageMeta, msgtype="client_new_job"):
         :param launcher: the name of the entity that launched this job, for logging purposes
         """
         self.job_id = job_id
+        self.priority = priority
         self.course_id = course_id
         self.task_id = task_id
         self.inputdata = inputdata

--- a/inginious/frontend/submission_manager.py
+++ b/inginious/frontend/submission_manager.py
@@ -185,7 +185,7 @@ class WebAppSubmissionManager:
             submission["tests"] = {} # Be sure tags are reinitialized
             submissionid = self._database.submissions.insert(submission)
 
-        jobid = self._client.new_job(task, inputdata,
+        jobid = self._client.new_job(1, task, inputdata,
                                      (lambda result, grade, problems, tests, custom, state, archive, stdout, stderr:
                                       self._job_done_callback(submissionid, task, result, grade, problems, tests, custom, state, archive, stdout, stderr, copy)),
                                      "Frontend - {}".format(submission["username"]), debug, ssh_callback)
@@ -271,7 +271,7 @@ class WebAppSubmissionManager:
 
         ssh_callback = lambda host, port, password: self._handle_ssh_callback(submissionid, host, port, password)
 
-        jobid = self._client.new_job(task, inputdata,
+        jobid = self._client.new_job(0, task, inputdata,
                                      (lambda result, grade, problems, tests, custom, state, archive, stdout, stderr:
                                       self._job_done_callback(submissionid, task, result, grade, problems, tests, custom, state, archive, stdout, stderr, True)),
                                      "Frontend - {}".format(username), debug, ssh_callback)

--- a/inginious/frontend/tests/TestParsableText.py
+++ b/inginious/frontend/tests/TestParsableText.py
@@ -24,7 +24,7 @@ class TestHookManager(object):
         assert '<non existing tag>' not in rendered
 
     def test_parsable_text_once(self):
-        def fake_parser(input, language, show_everything):
+        def fake_parser(string, show_everything=False, translation=None, initial_header_level=3, debug=False):
             fake_parser.count += 1
             return ""
 


### PR DESCRIPTION
This PR aims at bringing a quick solution for replays with the current backend architecture and replaces the round-robin made over the available agents by a job priority based scheduling. The jobs are stored in a priority queue which is popped every time the queue update function is called. 

In order to maximize the agents occupancy, the queue is popped as many times there are agents available. If a job cannot be treated by an agent, it is pushed back into the queue with a lower priority, so that it won't be prevent other jobs to run.

Currently two priorities are used. Maybe it would be interesting to use an enum or something else and set the replay priority very low to allow new kind of jobs, and to prevent normal jobs that were put back to the queue with lower priority to become less prioritary than replays.