### PR TITLE
Change input field to register for a course as 'password' type

### DIFF
--- a/inginious/frontend/templates/mycourses.html
+++ b/inginious/frontend/templates/mycourses.html
@@ -118,7 +118,7 @@ $else:
         </div>
         <div class="form-group col-sm-4">
             <label class="sr-only" for="register_password">$:_("Password")</label>
-            <input class="form-control" type="text" id="register_password" name="register_password" disabled="disabled" placeholder="$:_('Password')">
+            <input class="form-control" type="password" id="register_password" name="register_password" disabled="disabled" placeholder="$:_('Password')">
         </div>
         <div class="col-sm-12"><button type="submit" class="btn btn-block btn-default">$:_("Register")</button></div>
     </form>


### PR DESCRIPTION
This changes the input field to register for a course as a 'password' type rather than a plain text type. This gives a better security to the course password. 