### PR TITLE
Doc update : replace libzmq-dev by libzmq3-dev

### DIFF
--- a/doc/install_doc/installation.rst
+++ b/doc/install_doc/installation.rst
@@ -59,7 +59,7 @@ The previously mentioned dependencies can be installed, for Ubuntu 16.04+:
 ::
 
     # curl -fsSL https://get.docker.com/ | sh #This will setup the Docker repo
-    # apt-get install git mongodb gcc tidy python3 python3-pip python3-dev libzmq-dev
+    # apt-get install git mongodb gcc tidy python3 python3-pip python3-dev libzmq3-dev
 
 You may also add ``libldap2-dev libsasl2-dev libssl-dev`` if you want to use the LDAP auth plugin and
 ``libxmlsec1-dev libltdl-dev`` for the SAML2 auth plugin


### PR DESCRIPTION
Ubuntu 17+ no longer provides the package [libzmq-dev](https://packages.ubuntu.com/search?keywords=libzmq-dev), we should use libzmq3-dev instead

Tested on Ubuntu 18.04 / 19.04 