### PR TITLE
Store additional fields

### DIFF
--- a/inginious/frontend/pages/preferences/bindings.py
+++ b/inginious/frontend/pages/preferences/bindings.py
@@ -6,6 +6,7 @@
 """ Auth bindings page """
 import web
 
+from pymongo import ReturnDocument
 from inginious.frontend.pages.utils import INGIniousAuthPage
 
 
@@ -47,8 +48,10 @@ class BindingsPage(INGIniousAuthPage):
                 error = True
                 msg = _("Incorrect authentication binding.")
             elif len(user_data.get("bindings", {}).keys()) > 1 or "password" in user_data:
-                user_data = self.database.users.find_one_and_update({"username": self.user_manager.session_username()},
-                                                        {"$unset": {"bindings." + auth_id: 1}})
+                user_data = self.database.users.find_one_and_update(
+                    {"username": self.user_manager.session_username()},
+                    {"$unset": {"bindings." + auth_id: 1}},
+                    return_document=ReturnDocument.AFTER)
             else:
                 error = True
                 msg = _("You must set a password before removing all bindings.")

--- a/inginious/frontend/plugins/auth/facebook_auth.py
+++ b/inginious/frontend/plugins/auth/facebook_auth.py
@@ -38,7 +38,7 @@ class FacebookAuthMethod(AuthMethod):
             r = facebook.get('https://graph.facebook.com/me?fields=id,name,email')
             profile = json.loads(r.content.decode('utf-8'))
             auth_storage["oauth_state"] = facebook.state
-            return str(profile["id"]), profile["name"], profile["email"]
+            return str(profile["id"]), profile["name"], profile["email"], {}
         except:
             return None, None
 

--- a/inginious/frontend/plugins/auth/github_auth.py
+++ b/inginious/frontend/plugins/auth/github_auth.py
@@ -37,7 +37,7 @@ class GithubAuthMethod(AuthMethod):
             r = github.get('https://api.github.com/user/emails')
             profile["email"] = json.loads(r.content.decode('utf-8'))[0]["email"]
             realname = profile["name"] if profile.get("name", None) else profile["login"]
-            return str(profile["id"]), realname, profile["email"]
+            return str(profile["id"]), realname, profile["email"], {}
         except:
             return None
 

--- a/inginious/frontend/plugins/auth/google_auth.py
+++ b/inginious/frontend/plugins/auth/google_auth.py
@@ -42,7 +42,7 @@ class GoogleAuthMethod(AuthMethod):
 
             response = google.get('https://www.googleapis.com/oauth2/v3/userinfo')
             profile = json.loads(response.content.decode('utf-8'))
-            return str(profile["sub"]), profile["name"], profile["email"]
+            return str(profile["sub"]), profile["name"], profile["email"], {}
         except Exception as e:
             return None
 

--- a/inginious/frontend/plugins/auth/ldap_auth.py
+++ b/inginious/frontend/plugins/auth/ldap_auth.py
@@ -113,7 +113,7 @@ class LDAPAuthenticationPage(AuthenticationPage):
 
             conn.unbind()
 
-            self.user_manager.bind_user(id, (username, realname, email))
+            self.user_manager.bind_user(id, (username, realname, email, {}))
             
             auth_storage = self.user_manager.session_auth_storage().setdefault(id, {})
             raise web.seeother(auth_storage.get("redir_url", "/"))

--- a/inginious/frontend/plugins/auth/linkedin_auth.py
+++ b/inginious/frontend/plugins/auth/linkedin_auth.py
@@ -43,7 +43,7 @@ class LinkedInAuthMethod(AuthMethod):
                 if contact["type"] == "EMAIL":
                     profile["emailAddress"] = contact["handle~"]["emailAddress"]
                     break
-            return str(profile["id"]), profile["localizedFirstName"] + " " + profile["localizedLastName"], profile["emailAddress"]
+            return str(profile["id"]), profile["localizedFirstName"] + " " + profile["localizedLastName"], profile["emailAddress"], {}
         except Exception as e:
             return None
 

--- a/inginious/frontend/plugins/auth/saml2_auth.py
+++ b/inginious/frontend/plugins/auth/saml2_auth.py
@@ -74,12 +74,16 @@ class SAMLAuthMethod(AuthMethod):
             realname = attrs[self._settings["attributes"]["cn"]][0]
             email = attrs[self._settings["attributes"]["email"]][0]
 
+            additional = {}
+            for field, urn in self._settings.get("additional", {}).items():
+                additional[field] = attrs[urn][0]
+
             # Redirect to desired url
             self_url = OneLogin_Saml2_Utils.get_self_url(req)
             if 'RelayState' in input_data and self_url != input_data['RelayState']:
                 redirect_url = auth.redirect_to(input_data['RelayState'])
                 # Initialize session in user manager and update cache
-                return (str(username), realname, email) if redirect_url == auth_storage["redir_url"] else None
+                return (str(username), realname, email, additional) if redirect_url == auth_storage["redir_url"] else None
         else:
             logging.getLogger('inginious.webapp.plugin.auth.saml').error("Errors while processing response : ",
                                                                          ", ".join(errors))

--- a/inginious/frontend/plugins/auth/saml2_auth.py
+++ b/inginious/frontend/plugins/auth/saml2_auth.py
@@ -76,7 +76,7 @@ class SAMLAuthMethod(AuthMethod):
 
             additional = {}
             for field, urn in self._settings.get("additional", {}).items():
-                additional[field] = attrs[urn][0]
+                additional[field] = attrs[urn][0] if urn in attrs else ""
 
             # Redirect to desired url
             self_url = OneLogin_Saml2_Utils.get_self_url(req)

--- a/inginious/frontend/plugins/auth/twitter_auth.py
+++ b/inginious/frontend/plugins/auth/twitter_auth.py
@@ -42,7 +42,7 @@ class TwitterAuthMethod(AuthMethod):
             r = twitter.get('https://api.twitter.com/1.1/account/verify_credentials.json?include_email=true')
             profile = json.loads(r.content.decode('utf-8'))
             auth_storage["session"] = twitter
-            return str(profile["id"]), profile["name"], profile["email"]
+            return str(profile["id"]), profile["name"], profile["email"], {}
         except:
             return None
 

--- a/inginious/frontend/templates/mycourses.html
+++ b/inginious/frontend/templates/mycourses.html
@@ -73,7 +73,7 @@ $# Start content
                 </div>
             </a>
     $else:
-        <a href="#register" class="list-group-item list-group-item-action row disabled">$:_("You are not registered to any course")</a>
+        <a href="#register" class="list-group-item list-group-item-action disabled">$:_("You are not registered to any course")</a>
 </div>
 <hr/>
 $if user_manager.user_is_superadmin():

--- a/inginious/frontend/templates/preferences/bindings.html
+++ b/inginious/frontend/templates/preferences/bindings.html
@@ -54,10 +54,14 @@ $for id, auth_method in auth_methods.items():
                         $:auth_method.get_imlink()
                     </div>
                     <div class="col-md-11">
-                        <p>$:_("Identifier:") $bindings[id][0]</p>
-                        <!--<p>Fields: </p>-->
+                        <p>$:_("Identifier"): $bindings[id][0]</p>
+                        $if bindings[id][1]:
+                            <p>$:_("Additional fields"): </p>
+                            <ul>
+                                $for key, val in bindings[id][1].items():
+                                    <li>$id.$key : $val</li>
+                            </ul>
                     </div>
-
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This PR stores the additional fields returned by auth methods in the appropriate sturcture in database. Each auth method has a custom dict to store key and values for each user.

An implementation is given for the SAML auth method. An ``additional`` dictionary is specified in the settings with ``key: value`` corresponding to an identifier you want the attribute to be accessed to. For instance : 

    - plugin_module: "inginious.frontend.plugins.auth.saml2_auth"
          id: uclouvain
          name: "UCLouvain SSO"
          ...
          attributes:
              uid: "urn:oid:0.9.2342.19200300.100.1.1"
              email: "urn:oid:0.9.2342.19200300.100.1.3"
              cn: "urn:oid:2.5.4.3"
          additional:
              noma: "urn:oid:1.3.6.1.4.1.20613.2.1.8"
              anneeetude: "urn:oid:1.3.6.1.4.1.20613.2.1.9"

A typical additional fields dict could therefore be:

    {"noma": "28581100", "anneeetude": "ELEC 2MS/G"}

This PR does not add any data in the student lists yet as there are pending PRs already modifying this view.