### PR TITLE
Previewable pages

### DIFF
--- a/inginious/frontend/pages/course.py
+++ b/inginious/frontend/pages/course.py
@@ -6,11 +6,15 @@
 """ Course page """
 import web
 
-from inginious.frontend.pages.utils import INGIniousAuthPage, INGIniousPage
+from inginious.frontend.pages.utils import INGIniousAuthPage
 
 
-class CoursePage(INGIniousPage):
+class CoursePage(INGIniousAuthPage):
     """ Course page """
+
+    def preview_allowed(self, courseid):
+        course = self.get_course(courseid)
+        return course.get_accessibility().is_open() and course.allow_preview()
 
     def get_course(self, courseid):
         """ Return the course """
@@ -21,7 +25,7 @@ class CoursePage(INGIniousPage):
 
         return course
 
-    def POST(self, courseid):  # pylint: disable=arguments-differ
+    def POST_AUTH(self, courseid):  # pylint: disable=arguments-differ
         """ POST request """
         course = self.get_course(courseid)
 
@@ -32,7 +36,7 @@ class CoursePage(INGIniousPage):
 
         return self.show_page(course)
 
-    def GET(self, courseid):  # pylint: disable=arguments-differ
+    def GET_AUTH(self, courseid):  # pylint: disable=arguments-differ
         """ GET request """
         course = self.get_course(courseid)
         return self.show_page(course)

--- a/inginious/frontend/pages/utils.py
+++ b/inginious/frontend/pages/utils.py
@@ -146,6 +146,8 @@ class INGIniousAuthPage(INGIniousPage):
                 return self.template_helper.get_renderer().auth(self.user_manager.get_auth_methods(), False)
 
             return self.GET_AUTH(*args, **kwargs)
+        elif self.preview_allowed(*args, **kwargs):
+            return self.GET_AUTH(*args, **kwargs)
         else:
             return self.template_helper.get_renderer().auth(self.user_manager.get_auth_methods(), False)
 
@@ -170,9 +172,17 @@ class INGIniousAuthPage(INGIniousPage):
                     return self.GET_AUTH(*args, **kwargs)
                 else:
                     return self.template_helper.get_renderer().auth(self.user_manager.get_auth_methods(), True)
+            elif self.preview_allowed(*args, **kwargs):
+                return self.POST_AUTH(*args, **kwargs)
             else:
                 return self.template_helper.get_renderer().auth(self.user_manager.get_auth_methods(), False)
 
+    def preview_allowed(self, *args, **kwargs):
+        """
+            If this function returns True, the auth check is disabled.
+            Override this function with a custom check if needed.
+        """
+        return False
 
 class SignInPage(INGIniousAuthPage):
     def GET_AUTH(self, *args, **kwargs):


### PR DESCRIPTION
Add a mechanism to preview auth pages (i.e. pages that globally behave as auth pages, but are previewable under some circumstances).

Now the Course page asks for a login if the course is not previewable, rather than saying "you're not registered".
The same thing goes for the Task page.