### PR TITLE
Fix LTI relative urls

### DIFF
--- a/inginious/frontend/app.py
+++ b/inginious/frontend/app.py
@@ -89,7 +89,8 @@ urls = (
     r'/lti/([^/]+)/([^/]+)', 'inginious.frontend.pages.lti.LTILaunchPage',
     r'/lti/bind', 'inginious.frontend.pages.lti.LTIBindPage',
     r'/lti/task', 'inginious.frontend.pages.lti.LTITaskPage',
-    r'/lti/login', 'inginious.frontend.pages.lti.LTILoginPage'
+    r'/lti/login', 'inginious.frontend.pages.lti.LTILoginPage',
+    r'/lti/asset/(.*)', 'inginious.frontend.pages.lti.LTIAssetPage'
 )
 
 urls_maintenance = (

--- a/inginious/frontend/pages/lti.py
+++ b/inginious/frontend/pages/lti.py
@@ -30,6 +30,18 @@ class LTITaskPage(INGIniousAuthPage):
         return BaseTaskPage(self).POST(courseid, taskid, True)
 
 
+class LTIAssetPage(INGIniousAuthPage):
+    def is_lti_page(self):
+        return True
+
+    def GET_AUTH(self, asset_url):
+        data = self.user_manager.session_lti_info()
+        if data is None:
+            raise web.notfound()
+        (courseid, _) = data['task']
+        raise web.redirect(self.app.get_homepath() + "/course/{courseid}/{asset_url}".format(courseid=courseid, asset_url=asset_url))
+
+
 class LTIBindPage(INGIniousAuthPage):
     def is_lti_page(self):
         return False

--- a/inginious/frontend/parsable_text.py
+++ b/inginious/frontend/parsable_text.py
@@ -7,6 +7,7 @@
 import html
 import gettext
 from datetime import datetime
+from urllib.parse import urlparse
 
 import tidylib
 from docutils import core, nodes
@@ -148,7 +149,18 @@ class _CustomHTMLWriter(html4css1.Writer, object):
             """ Ensures all links to outside this instance of INGInious have target='_blank' """
             if tagname == 'a' and "href" in attributes and not attributes["href"].startswith('#'):
                 attributes["target"] = "_blank"
+            if 'path' in web.ctx and '/lti/' in web.ctx.path:
+                if tagname == 'a' and 'href' in attributes:
+                    attributes['href'] = self.rewrite_lti_url(attributes['href'])
+                elif tagname == 'img' and 'src' in attributes:
+                    attributes['src'] = self.rewrite_lti_url(attributes['src'])
             return html4css1.HTMLTranslator.starttag(self, node, tagname, suffix, empty, **attributes)
+
+        @staticmethod
+        def rewrite_lti_url(url):
+            if urlparse(url).netloc: # If URL is absolute, don't do anything
+                return url
+            return 'asset/' + url
 
         def visit_table(self, node):
             """ Remove needless borders """


### PR DESCRIPTION
Using links or images in the description of tasks and serving them over LTI doesn't work. This patch changes the RST HTML writer so that it rewrites relative URLs to use an intermediate page that will redirect the request to the correct asset URL using an HTTP 301.