### PR TITLE
Specify version for msgpack-python in the Docker container

### DIFF
--- a/base-containers/base/Dockerfile
+++ b/base-containers/base/Dockerfile
@@ -12,7 +12,7 @@ RUN     yum clean metadata && \
         yum -y install epel-release && \
         yum -y upgrade && \
         yum -y install python python36-pip python36 zip unzip tar sed openssh-server openssl bind-utils iproute file && \
-        pip3.6 install msgpack-python pyzmq jinja2 PyYAML timeout-decorator ipython && \
+        pip3.6 install "msgpack-python<1.0" pyzmq jinja2 PyYAML timeout-decorator ipython && \
         sed -i "s/override_install_langs=en_US.utf8/#override_install_langs=en_US.utf8/g" /etc/yum.conf && \
         yum -y reinstall glibc-common && \
         yum clean all


### PR DESCRIPTION
Recently, in #520, the version of `msgpack-python` and `web.py` was specified for INGInious itself in version 0.6. For `msgpack-python`,  this is due to the release of version 1.0, which changes how encoding is handled. To allow the docker containers to communicate with INGInious, we must ensure that the same major version of the library is used for both the container and INGInious itself. This PR places the same restriction on the major version of the library in the base container, as was done for INGInious in #520. If this change is not performed, running all tasks, except mcq, will result in errors like this one

```
An internal error occurred. Please retry later. If the error persists, send an email to the course administrator. [Submission #5eb3da069949682704d3cb19]
The grader did not return a readable output : 'NoneType' object has no attribute 'items'
```

This fixes the bug described in #524 