### PR TITLE
Submissions list: add a filter for crashes and timeouts

### DIFF
--- a/inginious/frontend/pages/course_admin/submissions.py
+++ b/inginious/frontend/pages/course_admin/submissions.py
@@ -152,6 +152,7 @@ class CourseSubmissionsPage(INGIniousSubmissionAdminPage):
                                              ],
                                              submit_time_between=submit_time_between,
                                              keep_only_evaluation_submissions=must_keep_best_submissions_only,
+                                             keep_only_crashes="crashes_only" in user_input,
                                              sort_by=(user_input.sort_by, user_input.order == "1"),
                                              limit=limit+1)
 

--- a/inginious/frontend/pages/course_admin/utils.py
+++ b/inginious/frontend/pages/course_admin/utils.py
@@ -68,6 +68,7 @@ class INGIniousSubmissionAdminPage(INGIniousAdminPage):
                                  with_tags=None,
                                  grade_between=None, submit_time_between=None,
                                  keep_only_evaluation_submissions=False,
+                                 keep_only_crashes=False,
                                  sort_by=("submitted_on", True),
                                  limit=None):
         """
@@ -87,6 +88,7 @@ class INGIniousSubmissionAdminPage(INGIniousAdminPage):
         :param submit_time_between: a tuple of two dates or None ([datetime, None], [None, datetime] or [None, None])
                that indicates bounds on the submission time of the submission. Format: "%Y-%m-%d %H:%M:%S"
         :param keep_only_evaluation_submissions: True to keep only submissions that are counting for the evaluation
+        :param keep_only_crashes: True to keep only submissions that timed out or crashed
         :param sort_by: a tuple (sort_column, ascending) where sort_column is in ["submitted_on", "username", "grade", "taskid"]
                and ascending is either True or False.
         :param limit: an integer representing the maximum number of submission to list.
@@ -144,6 +146,10 @@ class INGIniousSubmissionAdminPage(INGIniousAdminPage):
             # TODO it would be nice to display this in the interface. However, this should never happen because
             # we have a nice JS interface that prevents this.
             pass
+
+        # Only crashed or timed-out submissions
+        if keep_only_crashes:
+            filter["result"] = {"$in": ["crash", "timeout"]}
 
         # Only evaluation submissions
         user_tasks = self.database.user_tasks.find(base_filter)

--- a/inginious/frontend/templates/course_admin/submissions.html
+++ b/inginious/frontend/templates/course_admin/submissions.html
@@ -100,6 +100,7 @@ $if len(old_input.tasks) == 1:
                             <!-- Content coolspse Advanced query -->
                             <!-- Checkboxs -->
                             $ list_checkboxes = [("eval", _("Only evaluation submissions")),
+                            $                    ("crashes_only", _("Only timeouts and crashes")),
                             $                    ("show_tags", _("Show tags")),
                             $                    ("show_id", _("Show submission id")),
                             $                    ("show_task_name", _("Show task name")),


### PR DESCRIPTION
Fixes Issue #523 

This adds a single checkbox to filter submissions that crashed or timed out.

Do you prefer a single checkbox like this or a radio group with three choices (i.e., timeout, crash, no filter)?