### PR TITLE
Use another function to render jinja templates

### DIFF
--- a/inginious/frontend/pages/course.py
+++ b/inginious/frontend/pages/course.py
@@ -16,7 +16,7 @@ def handle_course_unavailable(app_homepath, template_helper, user_manager, cours
         user_info = user_manager.get_user_info(username)
         if course.is_registration_possible(user_info):
             raise web.seeother(app_homepath + "/register/" + course.get_id())
-    return template_helper.get_renderer(use_jinja=True).course_unavailable(reason=reason)
+    return template_helper.render("course_unavailable.html", reason=reason)
 
 
 class CoursePage(INGIniousAuthPage):

--- a/inginious/frontend/pages/course_register.py
+++ b/inginious/frontend/pages/course_register.py
@@ -30,7 +30,7 @@ class CourseRegisterPage(INGIniousAuthPage):
 
     def GET_AUTH(self, courseid):
         course, _ = self.basic_checks(courseid)
-        return self.template_helper.get_renderer(use_jinja=True).course_register(course=course, error=False)
+        return self.template_helper.render("course_register.html", course=course, error=False)
 
     def POST_AUTH(self, courseid):
         course, username = self.basic_checks(courseid)
@@ -40,4 +40,4 @@ class CourseRegisterPage(INGIniousAuthPage):
         if success:
             raise web.seeother(self.app.get_homepath() + "/course/" + course.get_id())
         else:
-            return self.template_helper.get_renderer(use_jinja=True).course_register(course=course, error=True)
+            return self.template_helper.render("course_register.html", course=course, error=True)

--- a/inginious/frontend/pages/courselist.py
+++ b/inginious/frontend/pages/courselist.py
@@ -29,4 +29,4 @@ class CourseListPage(INGIniousPage):
         open_courses = {courseid: course for courseid, course in all_courses.items() if course.is_open_to_non_staff()}
         open_courses = OrderedDict(sorted(iter(open_courses.items()), key=lambda x: x[1].get_name(self.user_manager.session_language())))
 
-        return self.template_helper.get_renderer(use_jinja=True).courselist(open_courses=open_courses, user_info=user_info)
+        return self.template_helper.render("courselist.html", open_courses=open_courses, user_info=user_info)

--- a/inginious/frontend/pages/marketplace.py
+++ b/inginious/frontend/pages/marketplace.py
@@ -56,7 +56,7 @@ class Marketplace(INGIniousAuthPage):
         if errors is None:
             errors = []
         courses = get_all_marketplace_courses()
-        return self.template_helper.get_renderer(use_jinja=True).marketplace(courses=courses, errors=errors)
+        return self.template_helper.render("marketplace.html", courses=courses, errors=errors)
 
 
 def import_course(course, new_courseid, username, course_factory):

--- a/inginious/frontend/pages/marketplace_course.py
+++ b/inginious/frontend/pages/marketplace_course.py
@@ -57,4 +57,4 @@ class MarketplaceCourse(INGIniousAuthPage):
         if errors is None:
             errors = []
 
-        return self.template_helper.get_renderer(use_jinja=True).marketplace_course(course=course, errors=errors)
+        return self.template_helper.render("marketplace_course.html", course=course, errors=errors)

--- a/inginious/frontend/templates/layout_jinja.html
+++ b/inginious/frontend/templates/layout_jinja.html
@@ -88,9 +88,9 @@
         CodeMirror.modeURL = "{{get_homepath(True)}}/static/js/codemirror/mode/%N/%N.js";
     </script>
 
-    {{ template_helper.call('css') }}
-    {{ template_helper.call('javascript_header') }}
-    {{ template_helper.call('header_hook') }}
+    {{ template_helper.call('css') | safe }}
+    {{ template_helper.call('javascript_header') | safe }}
+    {{ template_helper.call('header_hook') | safe }}
     {% endblock %}
 </head>
 


### PR DESCRIPTION
* This allows to call subfolder when using use_jinja=True
* and will allow to simply remove get_renderer and get_custom_renderer when the migration is done.