### PR TITLE
Fix jobid handling

### DIFF
--- a/inginious/common/messages.py
+++ b/inginious/common/messages.py
@@ -7,7 +7,7 @@ from typing import Dict, Optional, Any, Union, Tuple, List
 from inginious.common.message_meta import MessageMeta
 
 # JobId of the backend, composed with the address of the client and the client job id
-BackendJobId = Tuple[bytes, str]
+BackendJobId = str
 ClientJobId = str
 SPResult = Tuple[str, str]
 


### PR DESCRIPTION
Previously, the client "job id" and the backend "job id" were different.
The backend job id was actually a tuple containing the address of the client and the jobid it gave.

A very simple form of authetication was then used to allow (or not) clients to access data or kill a job: the Backend job id must be the same (i.e. the request should come from the original client).

In practice, this is a safety guarantee that is never used (at least we never seen it used in the wild) and we have problem with uwsgi-like setups where multiple frontend processes (and thus clients...) are started.

This PR then simply modify the backend job id to be the one sent by the client. The client should thus ensure that the id created is unique. uuid4(), as currently done, should be sufficient.