### PR TITLE
Adding the upcoming_tasks plugin

### DIFF
--- a/doc/install_doc/config_reference.rst
+++ b/doc/install_doc/config_reference.rst
@@ -369,6 +369,19 @@ A new configuration page named *Contest* appears on the administration page. To 
 *Enable contest plugin* box on the appropriate course. Please note that the plugin will override the task
 accessibility dates.
 
+
+Upcoming tasks plugin
+`````````````````````
+
+This plugin allows for students to easily visualize their upcoming tasks based on deadlines.
+The new page is available directly from the left main menu.
+
+To enable the plugin, add to your configuration file:
+::
+
+    plugins:
+        - plugin_module: inginious.frontend.plugins.upcoming_tasks
+
 Simple grader plugin
 ````````````````````
 

--- a/doc/teacher_doc/course_admin.rst
+++ b/doc/teacher_doc/course_admin.rst
@@ -76,7 +76,7 @@ When editing a task, you can enter basic informations and parameters in the *Bas
 
 Based on the type of problem you want to put for the task, you can select one of the two available *grading environment* in the *Environment* tab:
 
-- Select **Multiple Choice Question solver** if you only want to add *mcq* or *match* types of problems.
+- Select **Multiple Choice Question solver** if you only want to add *mcq* or *match* types of problems. Note, the *math* problem type from the problems-math plugin also uses this grading environment.
 - Select **Docker container** if you want to add some more complex problems which requires to write a grading script to access the students inputs.
 
 Adding/removing problems

--- a/inginious/frontend/plugins/upcoming_tasks/__init__.py
+++ b/inginious/frontend/plugins/upcoming_tasks/__init__.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of INGInious. See the LICENSE and the COPYRIGHTS files for
+# more information about the licensing of this file.
+#
+
+""" A plugin that allow students to see their futur work in a single place for all their courses """
+import os
+from collections import OrderedDict
+from datetime import datetime, timedelta
+import flask
+from flask import send_from_directory
+
+from inginious.frontend.pages.utils import INGIniousPage, INGIniousAuthPage
+
+PATH_TO_PLUGIN = os.path.abspath(os.path.dirname(__file__))
+
+def menu(template_helper):
+    """ Displays the link to the board on the main page, if the plugin is activated """
+    return template_helper.render("main_menu.html", template_folder=PATH_TO_PLUGIN + '/templates/')
+
+class StaticMockPage(INGIniousPage):
+    """ MockPage based on auto-evaluation plugin structure """
+
+    def GET(self, path):
+        return send_from_directory(os.path.join(PATH_TO_PLUGIN, "static"), path)
+
+    def POST(self, path):
+        return self.GET(path)
+
+
+class UpComingTasksBoard(INGIniousAuthPage):
+
+    def GET_AUTH(self):
+        """ Called when reaching the page """
+        time_planner = "unlimited"
+        return self.page(time_planner)
+
+    def POST_AUTH(self):
+        """ Called when modifying time planner """
+        user_input = flask.request.form
+        time_planner = user_input.get("time_planner", default="unlimited")
+        return self.page(time_planner)
+
+    def time_planner_conversion(self, string_time_planner):
+        """ Used to convert the time_planner options into int value """
+        if string_time_planner in ["7", "14", "30"]:
+            return int(string_time_planner)
+        return 100000
+
+    def page(self, time_planner):
+        """ General main method called for GET and POST """
+        username = self.user_manager.session_username()
+        all_courses = self.course_factory.get_all_courses()
+        time_planner = self.time_planner_conversion(time_planner)
+
+        # Get the courses id
+        open_courses = {courseid: course for courseid, course in all_courses.items()
+                        if self.user_manager.course_is_open_to_user(course, username, False) and
+                        self.user_manager.course_is_user_registered(course, username)}
+        open_courses = OrderedDict(sorted(iter(open_courses.items()), key=lambda x: x[1].get_name(self.user_manager.session_language())))
+
+        # Get last submissions for left panel
+        last_submissions = self.submission_manager.get_user_last_submissions(5, {"courseid": {"$in": list(open_courses.keys())}})
+        except_free_last_submissions = []
+        for submission in last_submissions:
+            try:
+                submission["task"] = open_courses[submission['courseid']].get_task(submission['taskid'])
+                except_free_last_submissions.append(submission)
+            except:
+                pass
+
+        # Get the courses tasks, remove finished ones and courses that have no available unfinished tasks with upcoming deadline in range
+        tasks_data = {}
+        succeeded_courses = []
+        for courseid, course in open_courses.items():
+            tasks = course.get_tasks()
+            outdated_tasks = [taskid for taskid, task in tasks.items() if (not task.get_accessible_time().is_open()) or ((task.get_accessible_time().get_soft_end_date()) > (datetime.now()+timedelta(days=time_planner)))]
+            new_user_task_list = course.get_task_dispenser().get_user_task_list([username])[username]
+            new_user_task_list = [task_id for task_id in new_user_task_list if task_id not in outdated_tasks]
+            tasks_data[courseid] = {taskid: {"succeeded": False, "grade": 0.0} for taskid in new_user_task_list}
+            user_tasks = self.database.user_tasks.find({"username": username, "courseid": course.get_id(), "taskid": {"$in": new_user_task_list}})
+            for user_task in user_tasks:
+                if not user_task["succeeded"]:
+                    tasks_data[courseid][user_task["taskid"]]["succeeded"] = user_task["succeeded"]
+                    tasks_data[courseid][user_task["taskid"]]["grade"] = user_task["grade"]
+                else:
+                    del tasks_data[courseid][user_task["taskid"]]
+            # Remove courses with no unfinished available tasks with deadline and lti courses
+            if (len(tasks_data[courseid]) == 0) or course.is_lti():
+                succeeded_courses.append(courseid)
+
+        # Remove succeeded courses (including lti courses)
+        for succeeded_course in succeeded_courses:
+            del open_courses[succeeded_course]
+
+        # Sort the courses based on the most urgent task for each course
+        open_courses = OrderedDict( sorted(iter(open_courses.items()), key=lambda x: (sort_by_deadline(x[1], tasks_data[x[0]].keys())[0]).get_accessible_time().get_soft_end_date() ))
+
+        return self.template_helper.render("coming_tasks.html",
+                                           template_folder=PATH_TO_PLUGIN + "/templates/",
+                                           open_courses=open_courses,
+                                           tasks_data=tasks_data,
+                                           sorting_method=sort_by_deadline,
+                                           time_planner=["7", "14", "30", "unlimited"],
+                                           submissions=except_free_last_submissions)
+
+
+def sort_by_deadline(course, user_urgent_task_list):
+    """ Given a course (object) and a list of user urgent tasksid,
+    returns the list of urgent tasks (objects) for that course ordered based on deadline """
+    course_tasks = course.get_tasks()
+    course_user_urgent_task_list = list(set(course_tasks).intersection(user_urgent_task_list))
+    ordered_tasks = sorted(course_user_urgent_task_list, key=lambda x: course.get_task(x).get_accessible_time().get_soft_end_date())
+    return [course_tasks[taskid] for taskid in ordered_tasks]
+
+
+def init(plugin_manager, _, _2, config):
+    """ Init the plugin """
+    plugin_manager.add_page('/coming_tasks', UpComingTasksBoard.as_view("upcomingtasksboardpage"))
+    plugin_manager.add_page('/plugins/coming_tasks/static/<path:path>', StaticMockPage.as_view("upcomingtasksstaticmockpage"))
+    plugin_manager.add_hook('main_menu', menu)

--- a/inginious/frontend/plugins/upcoming_tasks/templates/coming_tasks.html
+++ b/inginious/frontend/plugins/upcoming_tasks/templates/coming_tasks.html
@@ -1,0 +1,111 @@
+{# This file is part of INGInious. See the LICENSE and the COPYRIGHTS files for #}
+{# more information about the licensing of this file. #}
+
+{% extends "layout.html" %}
+{% block title %}{{ _("Urgent tasks") }}{% endblock %}
+
+{% block navbar %}
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item active"><a href="#"><i class="fa fa-th-list"></i> {{ _("Upcoming Tasks") }}
+                <span class="sr-only">{{ _("(current)") }}</span></a>
+            </li>
+        </ol>
+    </nav>
+{% endblock %}
+
+{% block column %}
+    <h3> {{ _("Upcoming tasks") }}</h3>
+    <div class="alert alert-warning" role="alert">
+        {{ _("This page lists the coming tasks ordered on deadlines for courses you are registered in.") }}
+    </div>
+    <div class="list-group mb-3">
+        <a class="list-group-item list-group-item-action list-group-item-info" href="{{ get_homepath() }}/courselist">
+            <i class="fa fa-fw fa-th-list"></i>
+            {{ _("Course list") }}
+        </a>
+    </div>
+
+    <h3>{{ _("Last tried exercises") }}</h3>
+    <div class="list-group">
+        {% if submissions %}
+            {% for submission in submissions %}
+                <a class="list-group-item list-group-item-action
+                    {% if submission['status'] == 'done' and submission['result'] == 'success' %}
+                        list-group-item-success
+                    {% elif submission['status'] == 'done' and submission['result'] == 'save' %}
+                        list-group-item-info
+                    {% elif submission['status'] == 'waiting' %}
+                        list-group-item-warning
+                    {% else %}
+                        list-group-item-danger
+                    {% endif %}"
+                    href="{{ get_homepath() }}/course/{{submission['courseid']}}/{{submission['taskid']}}">
+                    <b>{{ submission["task"].get_course().get_name(user_manager.session_language()) }}</b>: {{ submission["task"].get_name(user_manager.session_language()) }}
+                </a>
+            {% endfor %}
+        {% else %}
+            <a class="list-group-item list-group-item-action disabled submission-empty">{{ _("No submissions") }}</a>
+        {% endif %}
+    </div>
+    {{ template_helper.call('main_menu', template_helper=template_helper) | safe }}
+{% endblock %}
+
+
+{% block content %}
+<h2>{{ _("My Upcoming Tasks") }}
+<div class="pull-right">
+        <div class="btn-group btn-group-sm">
+            <button class="btn btn-warning" data-toggle="modal" data-target="#timeModal">
+                <i class="fa fa-exchange"></i> {{_("Switch time planner")}}
+            </button>
+        </div>
+    </div>
+</h2>
+
+<div class="modal fade" id="timeModal" tabindex="-1" role="dialog" aria-labelledby="timeModalLabel" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <form method="post">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="timeModalLabel">{{_("Modify time planner")}}</h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <p>{{ _("This allows to display only the tasks whose deadline is in a certain temporal proximity.") }}</p>
+                    <label>{{ _("Number of days:") }}</label>
+                    <select class="form-control" id="new_time_planner" name="time_planner">
+                        {% for timeid in time_planner %}
+                            <option value="{{timeid}}">{{ timeid}}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">{{_("Cancel")}}</button>
+                    <button type="submit" class="btn btn-warning">{{_("Save changes")}}</button>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div class="list-group">
+    {%if open_courses %}
+        {% set username = user_manager.session_username() %}
+        {% for courseid, course in open_courses.items() %}
+                <div class="row">
+                    <div class="col-xs-12 col-md-8">
+                        {{ course.get_name(user_manager.session_language()) }}
+                        {% with course=course, tasks_data=tasks_data[courseid] %}
+                            {% include "upcoming.html" %}
+                        {% endwith %}
+                    </div>
+                </div>
+        {% endfor %}
+    {% else %}
+        <a href="#register" class="list-group-item list-group-item-action disabled">{{ _("You have no upcoming tasks") }}</a>
+    {% endif %}
+</div>
+{% endblock %}

--- a/inginious/frontend/plugins/upcoming_tasks/templates/main_menu.html
+++ b/inginious/frontend/plugins/upcoming_tasks/templates/main_menu.html
@@ -1,0 +1,3 @@
+<div class="list-group mb-3">
+    <a class="list-group-item list-group-item-action list-group-item-info" href="{{get_homepath()}}/coming_tasks"><i class="fa fa-rocket"></i> Upcoming Tasks</a>
+</div>

--- a/inginious/frontend/plugins/upcoming_tasks/templates/upcoming.html
+++ b/inginious/frontend/plugins/upcoming_tasks/templates/upcoming.html
@@ -1,0 +1,9 @@
+{# This file is part of INGInious. See the LICENSE and the COPYRIGHTS files for #}
+{# more information about the licensing of this file. #}
+
+{# Recursively print a list of sections and their content #}
+
+{% set level = level|default(3, true) %}
+{% with tasks=sorting_method(course, tasks_data.keys()) %}
+	{% include "upcoming_task_list.html" %}
+{% endwith %}

--- a/inginious/frontend/plugins/upcoming_tasks/templates/upcoming_task_list.html
+++ b/inginious/frontend/plugins/upcoming_tasks/templates/upcoming_task_list.html
@@ -1,0 +1,51 @@
+{# This file is part of INGInious. See the LICENSE and the COPYRIGHTS files for #}
+{# more information about the licensing of this file. #}
+
+{% set registered = user_manager.course_is_user_registered(course) %}
+
+<div id="course" class="section tasks_list card mb-4">
+
+    <div class="content list-group list-group-flush tasks-list">
+        {% for task in tasks %}
+            {% set taskid = task.get_id() %}
+            {% if taskid in tasks_data %}
+                {% set succeeded = tasks_data[taskid]["succeeded"] %}
+                {% set completion = tasks_data[taskid]["grade"] %}
+                <a href="{{ get_homepath() }}/course/{{course.get_id()}}/{{taskid}}" class="list-group-item list-group-item-action
+                    {% if not task.get_accessible_time().is_open() %} disabled {% endif %}">
+                    <div class="row">
+                        <div class="col-xs-12 col-md-7 pl-1">
+                            <i style="color: {% if succeeded %}#468847{% else %}transparent{% endif %};" class="fa fa-check"></i>
+                            {{ task.get_name(user_manager.session_language()) }}
+                            {% if not task.get_accessible_time().is_open() %}
+                                - <b> {{ _("deadline reached") }} </b>
+                            {% endif %}
+                            </div>
+                        <div class="col-xs-12 col-md-5">
+                            {{ "DEADLINE: "}}
+                            <b> {{ task.get_deadline() }} </b>
+                        </div>
+                        <div class="col-xs-12 col-md-5">
+                            {% if registered %}
+                                <div class="progress">
+                                    <div class="progress-bar bg-success" aria-valuenow="{{ completion | int }}" aria-valuemin="0" aria-valuemax="100" style="width: {{ completion | int }}%">
+                                        {% if completion.is_integer() %}{{ completion | int }}{% else %}{{ completion }}{% endif %} %
+                                    </div>
+                                </div>
+                            {% endif %}
+                        </div>
+                    </div>
+					
+                    <div id="tags_of_task" style="display:none;">
+                        {% for category in task.get_categories() %}
+                            {% set tag = tag_list[category] %}
+                            {% if tag.is_visible_for_student() or user_manager.has_staff_rights_on_course(course) %}
+                                <div id="tag" data-tag-name="{{tag.get_id()}}"></div>
+                            {% endif %}
+                        {% endfor %}
+                    </div>
+                </a>
+            {% endif %}
+        {% endfor %}
+    </div>
+</div>


### PR DESCRIPTION
This adds the upcoming_tasks plugin as one of the default plugin in the inginious.frontend.plugins folder.
It is enabled by adding the following line in the configuration.yaml file:
` - plugin_module: "inginious.frontend.plugins.upcoming_tasks" `

It adds a "Upcoming tasks" button in the left menu (from the homepage without selecting a course) that leads to a new page.
This page displays the available unsuccessful tasks that have a deadline for courses the user is registered in.
The tasks are displayed by sections (one section per course).
The sections (courses) are ordered based on their closest deadline then the tasks themselves are ordered based on their deadlines.
A button on the right allows to display only tasks with deadlines in a specific range.

If you find any potential issue please let me know.
The main default I can see for now is that some little parts of the user interface are in english and I don't know how to make them automatically translate to the user language .

Here is a little example:

Student with some work to do:
![image](https://user-images.githubusercontent.com/17684696/111807005-d3a13800-88d2-11eb-80f1-5ad438db2bd8.png)

Happy student:
![image](https://user-images.githubusercontent.com/17684696/111807139-f03d7000-88d2-11eb-98ce-d7b9c9d7a693.png)
