### PR TITLE
Set __file__ variable when using IPython

### DIFF
--- a/base-containers/base/bin/inginious-ipython
+++ b/base-containers/base/bin/inginious-ipython
@@ -20,5 +20,6 @@ shell.run_cell("from inginious_container_api.feedback import *", store_history=F
 shell.run_cell("from inginious_container_api.lang import *", store_history=False)
 shell.run_cell("from inginious_container_api.rst import *", store_history=False)
 shell.run_cell("from inginious_container_api.run_student import *", store_history=False)
+shell.run_cell("__file__ = \"" + sys.argv[0] + "\"", store_history=False)
 
 shell.safe_execfile_ipy(sys.argv[0])


### PR DESCRIPTION
By default, the variable __file__ is not defined when running a file with IPython
It gives the path to current source file

This PR defines the variable for the run file