### PR TITLE
lti/cookieless : correctly handle sessions

### DIFF
--- a/inginious/frontend/flask/mongo_sessions.py
+++ b/inginious/frontend/flask/mongo_sessions.py
@@ -19,6 +19,8 @@ from itsdangerous import Signer, BadSignature, want_bytes
 from flask.sessions import SessionMixin
 from werkzeug.datastructures import CallbackDict
 from flask.sessions import SessionInterface
+from werkzeug.exceptions import HTTPException
+from inginious.frontend.pages.lti import LTILaunchPage
 
 
 class MongoDBSession(CallbackDict, SessionMixin):
@@ -67,7 +69,15 @@ class MongoDBSessionInterface(SessionInterface):
     def open_session(self, app, request):
         # Check for cookieless session in the path
         path_session = re.match(r"(/@)([a-f0-9A-F_]*)(@)", request.path)
-        is_lti_launch = re.match(r"(/lti)", request.path)
+
+        # Check if currently accessed URL is LTI launch page
+        try:
+            # request.url_rule is not set yet here.
+            endpoint, args = app.create_url_adapter(request).match()
+            is_lti_launch = app.view_functions.get(endpoint).view_class == LTILaunchPage
+        except HTTPException:
+            is_lti_launch = False
+
         if path_session:  # Cookieless session
             cookieless = True
             sid = path_session.group(2)

--- a/inginious/frontend/flask/mongo_sessions.py
+++ b/inginious/frontend/flask/mongo_sessions.py
@@ -67,9 +67,13 @@ class MongoDBSessionInterface(SessionInterface):
     def open_session(self, app, request):
         # Check for cookieless session in the path
         path_session = re.match(r"(/@)([a-f0-9A-F_]*)(@)", request.path)
+        is_lti_launch = re.match(r"(/lti)", request.path)
         if path_session:  # Cookieless session
             cookieless = True
             sid = path_session.group(2)
+        elif is_lti_launch:
+            cookieless = True
+            sid = None
         else:
             cookieless = False
             sid = request.cookies.get(app.session_cookie_name)

--- a/inginious/frontend/pages/lti.py
+++ b/inginious/frontend/pages/lti.py
@@ -173,9 +173,9 @@ class LTILaunchPage(INGIniousPage):
     def POST(self, courseid, taskid):
         (sessionid, loggedin) = self._parse_lti_data(courseid, taskid)
         if loggedin:
-            return redirect(self.app.get_homepath() + "/@{}@/lti/task".format(sessionid))
+            return redirect(self.app.get_homepath() + "/lti/task")
         else:
-            return redirect(self.app.get_homepath() + "/@{}@/lti/login".format(sessionid))
+            return redirect(self.app.get_homepath() + "/lti/login")
 
     def _parse_lti_data(self, courseid, taskid):
         """ Verify and parse the data for the LTI basic launch """

--- a/inginious/frontend/pages/utils.py
+++ b/inginious/frontend/pages/utils.py
@@ -47,12 +47,6 @@ class INGIniousPage(MethodView):
         return flask.current_app
 
     def _pre_check(self, sessionid):
-        # Check for cookieless redirect
-        if not sessionid and flask.session.cookieless:
-            query_string = "?" + flask.request.query_string.decode("utf-8") if flask.request.query_string else ""
-            flask.request.view_args.update(sessionid=flask.session.sid)
-            return redirect(url_for(flask.request.endpoint, **flask.request.view_args) + query_string)
-
         # Check for language
         if "lang" in flask.request.args and flask.request.args["lang"] in self.app.l10n_manager.translations.keys():
             self.user_manager.set_session_language(flask.request.args["lang"])

--- a/inginious/frontend/user_manager.py
+++ b/inginious/frontend/user_manager.py
@@ -227,9 +227,6 @@ class UserManager:
         """ Creates an LTI cookieless session. Returns the new session id"""
 
         self._destroy_session()  # don't forget to destroy the current session
-
-        flask.current_app.session_interface.open_session(flask.current_app, flask.request)
-
         session_id = self._session.sid
 
         self._session["lti"] = {


### PR DESCRIPTION
This fixes erroneous code where session fetched was still the cookie one if available and never replaced. This resulted in displaying the same task on multiple-LTI-frame pages or more weird things according to the request sequence.

Moreover, Flask doesn't deal at all with session hotswap and its context stack, therefore the session manager creates the new session when it detects the LTI launch page is requested. Workaround code for some strange behaviours could then be removed.