### PR TITLE
Add new hooks: `submission_admin_menu` & `task_list_item`

### DIFF
--- a/doc/dev_doc/extensions_doc/plugins.rst
+++ b/doc/dev_doc/extensions_doc/plugins.rst
@@ -100,6 +100,40 @@ Each hook available in INGInious is described here, starting with its name and p
     Used to add links to the administration menu. This hook should return a tuple (link,name) 
     where link is the relative link from the index of the course administration.
     You can also return None.
+``submission_admin_menu`` (``course``, ``task``, ``submission`` ``template_helper``)
+    ``course`` : :ref:`inginious.frontend.courses.Course`
+    
+    ``task`` : :ref:`inginious.frontend.tasks.Task`
+
+    ``submission`` : OrderedDict
+
+    ``template_helper`` : :ref:`inginious.frontend.template_helper.TemplateHelper`
+
+    Returns : HTML or None.
+
+    Used to add HTML to the administration menu displayed at the top of a submission. 
+    ``course`` is the course the submission was made for.
+    ``task`` is the task the submission was made for.
+    ``submission`` is the submission's data.
+    ``template_helper`` is an object of type TemplateHelper, that can be useful to render templates.
+``task_list_item`` (``course``, ``task``, ``tasks_data`` ``template_helper``)
+    ``course`` : :ref:`inginious.frontend.courses.Course`
+    
+    ``task`` : :ref:`inginious.frontend.tasks.Task`
+
+    ``tasks_data`` : dict
+
+    ``template_helper`` : :ref:`inginious.frontend.template_helper.TemplateHelper`
+
+    Returns : HTML or None.
+
+    Used to add HTML underneath each item's progress bar in a course's task list (``/course/<courseid>``).
+    This hook is called once for each task the course has. 
+    If a course has 20 tasks, the hook is then called 20 times each time the task list is rendered.
+    ``course`` is the course the submission was made for.
+    ``task`` is the task the submission was made for.
+    ``tasks_data`` is a dictionary used by INGInious which contains the grade and completion status of each of the course's tasks for the visiting user.
+    ``template_helper`` is an object of type TemplateHelper, that can be useful to render templates.
 ``main_menu`` (``template_helper``)
     ``template_helper`` : :ref:`inginious.frontend.template_helper.TemplateHelper`
 

--- a/inginious/frontend/template_helper.py
+++ b/inginious/frontend/template_helper.py
@@ -28,6 +28,8 @@ class TemplateHelper(object):
         self._base_helpers = {"header_hook": (lambda **kwargs: self._generic_hook('header_html', **kwargs)),
                               "main_menu": (lambda **kwargs: self._generic_hook('main_menu', **kwargs)),
                               "course_menu": (lambda **kwargs: self._generic_hook('course_menu', **kwargs)),
+                              "submission_admin_menu": (lambda **kwargs: self._generic_hook('submission_admin_menu', **kwargs)),
+                              "task_list_item": (lambda **kwargs: self._generic_hook('task_list_item', **kwargs)),
                               "task_menu": (lambda **kwargs: self._generic_hook('task_menu', **kwargs)),
                               "welcome_text": (lambda **kwargs: self._generic_hook('welcome_text', **kwargs)),
                               "javascript_header": (lambda **_: self._javascript_helper("header")),

--- a/inginious/frontend/templates/course_admin/submission.html
+++ b/inginious/frontend/templates/course_admin/submission.html
@@ -76,6 +76,7 @@
                     </button>
                 </div>
             {% endif %}
+            {{ template_helper.call('submission_admin_menu', course=course, task=task, submission=submission, template_helper=template_helper) | safe }}
         </div>
     </form>
 </div>

--- a/inginious/frontend/templates/task_dispensers/task_list.html
+++ b/inginious/frontend/templates/task_dispensers/task_list.html
@@ -40,6 +40,7 @@
                                         {% if completion.is_integer() %}{{ completion | int }}{% else %}{{ completion }}{% endif %} %
                                     </div>
                                 </div>
+                                {{ template_helper.call('task_list_item', course=course, task=task, tasks_data=tasks_data, template_helper=template_helper) | safe }}
                             {% endif %}
                         </div>
                     </div>


### PR DESCRIPTION
This pull requests suggests adding two new hooks for the frontend: `submission_admin_menu` and `task_list_item`. 

Adding these hooks is motivated by my work on my plugin for adding custom coding style grades to submissions: https://github.com/PederHA/inginious-coding-style

The hooks are required in order to add the elements that are necessary for the plugin to display its custom elements. In order to understand the changes I am suggesting, I will try to explain their purpose and functionality.

## submission_admin_menu

This hook adds the ability for plugins to add HTML to the admin/tutor menu displayed at the top of a student submission.

![submission_admin_menu](https://pederha.github.io/inginious-coding-style/img/index/04_adminbutton.png)
_Example of adding a custom button ("Grade coding style") using `submission_admin_menu`._

### Parameters

**`course`**: `inginious.frontend.courses.Course`

The course the submission's task belongs to.

**`task`**: `inginious.frontend.tasks.Task`

The task the submission was made for.

**`submission`**: `OrderedDict`

The submission itself.

**`template_helper`**: `inginious.frontend.template_helper.TemplateHelper`

Template helper for rendering HTML.

Returns HTML or None

## task_list_item

This hook adds the ability for plugins to add HTML underneath the progress bar for each task on the course list page (`/courses/<courseid>`). The hook is called once for each task that the course has; for a course with 20 tasks, the hook is thus called 20 times when displaying `/courses/<courseid>`.

![task_list_item](https://pederha.github.io/inginious-coding-style/img/index/01_tasklist_grade.png)
_Example of adding a custom progress bar underneath the normal INGInious grade progress bar using `task_list_item`._

### Parameters

**`course`**: `inginious.frontend.courses.Course`

The course the task list belongs to.

**`task`**: `inginious.frontend.tasks.Task`

The task the list item is related to.

**`tasks_data`**: `dict`

A dictionary used by INGInious which contains the grade and completion status of each of the course's tasks for the visiting user.

**`template_helper`**: `inginious.frontend.template_helper.TemplateHelper`

Template helper for rendering HTML.

Returns HTML or None


## Final Notes

I understand that when making pull requests for new hooks, which arguments to pass onto the hook function is a matter of opinion, but I have tried to include the ones I deemed most relevant. I would appreciate feedback on that part, especially if you have certain guidelines you attempt to adhere to with regards to hook parameters that you feel I have not followed properly.