### PR TITLE
hotfix ssh_student

### DIFF
--- a/base-containers/base/bin/_run_student_intern
+++ b/base-containers/base/bin/_run_student_intern
@@ -119,7 +119,7 @@ if start_cmd["ssh"]:
     # Wait for user to connect and leave
     retval = ssh_wait(ssh_user)
 
-if start_cmd["teardown_script"] != "":
+if start_cmd["teardown_script"] is not None and len(start_cmd["teardown_script"]) > 0:
     # Run the teardown_script if there is one
     p2 = subprocess.Popen(shlex.split(start_cmd["teardown_script"]), preexec_fn=set_limits, stdin=fds[0], stdout=fds[1],
                          stderr=fds[2])


### PR DESCRIPTION
This error made the use of "ssh_student" with a python "run" script not correctly closing the student_container.

Actually it tried to run the teardown-script even if the string was None.
This issue, however, did not impact run_student nor ssh_student when using bash "run" script.

It should be merged ASAP.