### PR TITLE
Send LTI informatoin to the client

### DIFF
--- a/inginious/frontend/submission_manager.py
+++ b/inginious/frontend/submission_manager.py
@@ -287,7 +287,7 @@ class WebAppSubmissionManager:
         # Send LTI information to the client except "consumer_key"
         lti_info = self._user_manager.session_lti_info()
         for key in lti_info:
-            if key == "consumer_key": # Skip "consumer_key"
+            if key == "consumer_key" or key.startswith("outcome"): # Skip "consumer_key" and "outcome*"
                 continue
             self._logger.debug("LTI data : %s, %s",key, lti_info[key])
             # Add @lti_ prefix

--- a/inginious/frontend/submission_manager.py
+++ b/inginious/frontend/submission_manager.py
@@ -284,6 +284,16 @@ class WebAppSubmissionManager:
         inputdata["@random"] = states["random"] if "random" in states else []
         inputdata["@state"] = states["state"] if "state" in states else ""
 
+        # Send LTI information to the client except "consumer_key"
+        lti_info = self._user_manager.session_lti_info()
+        for key in lti_info:
+            if key == "consumer_key": # Skip "consumer_key"
+                continue
+            self._logger.debug("LTI data : %s, %s",key, lti_info[key])
+            # Add @lti_ prefix
+            key_str = "@lti_" + key;
+            inputdata[key_str] = lti_info[key]
+
         self._plugin_manager.call_hook("new_submission", submission=obj, inputdata=inputdata)
 
         self._before_submission_insertion(task, inputdata, debug, obj)

--- a/inginious/frontend/submission_manager.py
+++ b/inginious/frontend/submission_manager.py
@@ -286,13 +286,14 @@ class WebAppSubmissionManager:
 
         # Send LTI information to the client except "consumer_key"
         lti_info = self._user_manager.session_lti_info()
-        for key in lti_info:
-            if key == "consumer_key" or key.startswith("outcome"): # Skip "consumer_key" and "outcome*"
-                continue
-            self._logger.debug("LTI data : %s, %s",key, lti_info[key])
-            # Add @lti_ prefix
-            key_str = "@lti_" + key
-            inputdata[key_str] = lti_info[key]
+        if lti_info:
+            for key in lti_info:
+                if key == "consumer_key" or key.startswith("outcome"): # Skip "consumer_key" and "outcome*"
+                    continue
+                self._logger.debug("LTI data : %s, %s",key, lti_info[key])
+                # Add @lti_ prefix
+                key_str = "@lti_" + key
+                inputdata[key_str] = lti_info[key]
 
         self._plugin_manager.call_hook("new_submission", submission=obj, inputdata=inputdata)
 

--- a/inginious/frontend/submission_manager.py
+++ b/inginious/frontend/submission_manager.py
@@ -291,7 +291,7 @@ class WebAppSubmissionManager:
                 continue
             self._logger.debug("LTI data : %s, %s",key, lti_info[key])
             # Add @lti_ prefix
-            key_str = "@lti_" + key;
+            key_str = "@lti_" + key
             inputdata[key_str] = lti_info[key]
 
         self._plugin_manager.call_hook("new_submission", submission=obj, inputdata=inputdata)


### PR DESCRIPTION
The patch will allow the client to access LTI information within a grading container.
"consumer_key" and "outcome*" fields are excluded for security reason.