### PR TITLE
course_admin/task_edit: fix HTML escaping issues

### DIFF
--- a/inginious/frontend/templates/course_admin/task_edit.html
+++ b/inginious/frontend/templates/course_admin/task_edit.html
@@ -166,8 +166,8 @@
 <!-- Init the javascript for the subproblem tab -->
 <script type="text/javascript">
     delete_subproblem_message = '{{_("Are you sure that you want to delete this subproblem?")}}';
-    problem_data = {{ problemdata | safe }};
-    $(function(){ studio_load(problem_data); });
+    problem_data = {{ problemdata | tojson }};
+    $(function(){ studio_load(JSON.parse(problem_data)); });
 </script>
 
 {% endblock %}


### PR DESCRIPTION
This follows #703 that introduced HTML char escaping issues in Javascript strings (<,>, "). In particular, a closing ``</script>`` markup inside a JS string actually stop JS interpreter.

This way, the dict is dumped into JSON format in the Python code to keep the exercises order in the OrderedDict, and the ``tojson`` Jinja filters applies the appropriate escaping that works with ``JSON.parse``.