### PR TITLE
course_admin/task_edit: allows yaml author field to be empty

### DIFF
--- a/inginious/frontend/templates/course_admin/edit_tabs/basic.html
+++ b/inginious/frontend/templates/course_admin/edit_tabs/basic.html
@@ -42,7 +42,7 @@
     <label for="author" class="col-sm-2 control-label">{{ _("Author") }}</label>
     <div class="col-sm-10">
         {% if task_data.get('author',[]) is not string %}
-            {% set a= task_data.get('author',[]) | join(', ') %}
+            {% set a= task_data.get('author',[]) or [] | join(', ') %}
         {% else %}
             {% set a = task_data.get('author',[]) %}
         {% endif %}


### PR DESCRIPTION
Else it will fail as ``task_data.get('author',[])`` will return ``None``.