### PR TITLE
Fix issue #218

### DIFF
--- a/inginious/frontend/templates/course_admin/danger_zone.html
+++ b/inginious/frontend/templates/course_admin/danger_zone.html
@@ -139,7 +139,7 @@
                 </div>
                 <div class="card-body">
                     {{ _("<p> This will <b>permanently</b> remove the course and all its data (including tasks and backups) from INGInious.</p><p>To confirm your will, please type the course id below :</p>") | safe }}
-                    <form class="form-horizontal" method="post">
+                    <form class="form-horizontal" method="post" onkeydown="if (event.key == 'Enter') {$('#delete_modal').modal('show'); return false;}">
                         <input type="hidden" name="token" value="{{ thehash }}">
                         <div class="row">
                             <div class="col-md-6">


### PR DESCRIPTION
Replace the default submit behavior on 'enter' keypress by opening the 'delete_modal' modal.

This hack could also be used for the "archive course data" button which presents the same problem.