### PR TITLE
agents specific for ssh

### DIFF
--- a/base-containers/base/inginious_container_api/run_student.py
+++ b/base-containers/base/inginious_container_api/run_student.py
@@ -51,6 +51,7 @@ def run_student(cmd, container=None,
         - 253 means that the command timed out
         - 254 means that an error occurred while running the proxy
     """
+
     if not os.path.exists("/.__input/__shared_kernel"):  # disable run_student when the kernel is not shared (TODO fix me)
         print("run_student is not available with Kata yet")
         return 251

--- a/doc/admin_doc/commands_doc/inginious-agent-docker.rst
+++ b/doc/admin_doc/commands_doc/inginious-agent-docker.rst
@@ -15,6 +15,7 @@ INGInious to use a local backend, it is automatically run by ``inginious-webapp`
                            [--debug-ports DEBUG_PORTS] [--tmpdir TMPDIR]
                            [--concurrency CONCURRENCY] [-v] [--debugmode]
                            [--disable-autorestart]
+                           [--ssh]
                            [--runtime RUNTIME [RUNTIME ...]]
                            [--tasks TASKS | --fs {local}] [--fs-help]
                            backend
@@ -62,6 +63,10 @@ INGInious to use a local backend, it is automatically run by ``inginious-webapp`
 
    Disables the auto restart on agent failure.
 
+.. option:: --ssh
+
+    Allow this agent to handle tasks using ssh features.
+
 .. option:: --runtime
 
    Add a runtime, such as crun, runc or kata. If no runtime is given, the available runtimes are detected automatically.
@@ -73,6 +78,7 @@ INGInious to use a local backend, it is automatically run by ``inginious-webapp`
    - 'shared' indicates that the containers on this runtime use the host kernel (i.e. they are not VMs)"
 
    Common values are 'runc docker shared' and 'kata-runtime kata root'.
+
 
 .. option:: backend
 

--- a/doc/teacher_doc/run_file.rst
+++ b/doc/teacher_doc/run_file.rst
@@ -834,7 +834,8 @@ ssh_student
 
     *ssh_student*, as for *run_student* is not available in some environments, such as those running in OCI runtimes that do not share
     a common kernel between containers. ``kata`` is an example of such runtime. When ``ssh_student`` is not available,
-    it will exit with error code 251. The *ssh_student* feature also requires to allow internet connection in the environment configuration tab.
+    it will exit with error code 251. The *ssh_student* feature also requires to allow ssh and internet connection in the environment configuration tab.
+    Note, to use ssh_student, at least one inginious-agent in your deployment must handle ssh. For more details, see: :ref:`inginious-docker-agent<inginious-agent-docker>`
     
 
 

--- a/inginious-agent-docker
+++ b/inginious-agent-docker
@@ -86,6 +86,8 @@ if __name__ == "__main__":
                         action="store_true")
     parser.add_argument("--debugmode", help="Enables debug mode. For developers only.", action="store_true")
     parser.add_argument("--disable-autorestart", help="Disables the auto restart on agent failure.", action="store_true")
+    parser.add_argument("--ssh", help="Allow this agent to handle tasks with ssh features", action="store_true",
+                        default=False)
     parser.add_argument("--runtime", nargs='+', action=RuntimeParser,
                         help="Add a runtime. Expects at least 2 arguments: the name of the runtime (eg runc), "
                              "the name of the environment type (eg docker or kata). You can then add flags:\n"
@@ -93,7 +95,6 @@ if __name__ == "__main__":
                              "- 'shared' indicates that the containers on this runtime use the host kernel (i.e. they are not VMs)"
                              "\n"
                              "Common values are 'runc docker shared' and 'kata-runtime kata root'.")
-
     (args, fsprovider) = get_args_and_filesystem(parser)
 
     if not os.path.exists(args.tmpdir):
@@ -120,7 +121,7 @@ if __name__ == "__main__":
         # Create agent
         agent = DockerAgent(context, args.backend, args.friendly_name, args.concurrency, fsprovider,
                             address_host=args.debug_host, external_ports=args.debug_ports, tmp_dir=args.tmpdir,
-                            runtimes=args.runtime)
+                            runtimes=args.runtime, ssh_allowed=args.ssh)
 
         # Run!
         try:

--- a/inginious/agent/__init__.py
+++ b/inginious/agent/__init__.py
@@ -48,7 +48,7 @@ class Agent(object, metaclass=ABCMeta):
     An INGInious agent, that grades specific kinds of jobs, and interacts with a Backend.
     """
 
-    def __init__(self, context, backend_addr, friendly_name, concurrency, filesystem):
+    def __init__(self, context, backend_addr, friendly_name, concurrency, filesystem, ssh_allowed=False):
         """
         :param context: a ZMQ context to which the agent will be linked
         :param backend_addr: address of the backend to which the agent should connect. The format is the same as ZMQ
@@ -66,6 +66,7 @@ class Agent(object, metaclass=ABCMeta):
         self.__backend_addr = backend_addr
         self.__context = context
         self.__friendly_name = friendly_name
+        self.__ssh_allowed = ssh_allowed
         self.__backend_socket = self.__context.socket(zmq.DEALER)
         self.__backend_socket.ipv6 = True
 
@@ -111,7 +112,7 @@ class Agent(object, metaclass=ABCMeta):
 
         # Tell the backend we are up and have `concurrency` threads available
         self._logger.info("Saying hello to the backend")
-        await ZMQUtils.send(self.__backend_socket, AgentHello(self.__friendly_name, self.__concurrency, self.environments))
+        await ZMQUtils.send(self.__backend_socket, AgentHello(self.__friendly_name, self.__concurrency, self.environments, self.__ssh_allowed))
         self.__backend_last_seen_time = time.time()
 
         run_listen = self._loop.create_task(self.__run_listen())

--- a/inginious/agent/docker_agent/__init__.py
+++ b/inginious/agent/docker_agent/__init__.py
@@ -50,6 +50,7 @@ class DockerRunningJob:
     assigned_external_ports: List[int]
     student_containers: Set[str]  # container ids of student containers
     enable_network: bool
+    ssh_allowed: bool
 
 
 @dataclass
@@ -64,7 +65,7 @@ class DockerRunningStudentContainer:
 
 
 class DockerAgent(Agent):
-    def __init__(self, context, backend_addr, friendly_name, concurrency, tasks_fs: FileSystemProvider, address_host=None, external_ports=None, tmp_dir="./agent_tmp", runtimes=None):
+    def __init__(self, context, backend_addr, friendly_name, concurrency, tasks_fs: FileSystemProvider, address_host=None, external_ports=None, tmp_dir="./agent_tmp", runtimes=None, ssh_allowed=False):
         """
         :param context: ZeroMQ context for this process
         :param backend_addr: address of the backend (for example, "tcp://127.0.0.1:2222")
@@ -76,8 +77,9 @@ class DockerAgent(Agent):
         :param tmp_dir: temp dir that is used by the agent to start new containers
         :param type: type of the container ("docker" or "kata")
         :param runtime: runtime used by docker (the defaults are "runc" with docker or "kata-runtime" with kata)
+        :param ssh_allowed: boolean to make this agent accept tasks with ssh or not
         """
-        super(DockerAgent, self).__init__(context, backend_addr, friendly_name, concurrency, tasks_fs)
+        super(DockerAgent, self).__init__(context, backend_addr, friendly_name, concurrency, tasks_fs, ssh_allowed=ssh_allowed)
 
         self._runtimes = {x.envtype: x for x in runtimes} if runtimes is not None else None
 
@@ -268,6 +270,7 @@ class DockerAgent(Agent):
 
         try:
             enable_network = message.environment_parameters.get("network_grading", False)
+            ssh_allowed = message.environment_parameters.get("ssh_allowed", False)
             limits = message.environment_parameters.get("limits", {})
             time_limit = int(limits.get("time", 30))
             hard_time_limit = int(limits.get("hard_time", None) or time_limit * 3)
@@ -394,7 +397,8 @@ class DockerAgent(Agent):
             run_cmd=run_cmd,
             assigned_external_ports=list(ports.values()),
             student_containers=set(),
-            enable_network=enable_network
+            enable_network=enable_network,
+            ssh_allowed=ssh_allowed
         )
 
         self._containers_running[container_id] = info
@@ -568,9 +572,9 @@ class DockerAgent(Agent):
                                 socket_id = msg["socket_id"]
                                 ssh = msg["ssh"]
                                 assert "/" not in socket_id  # ensure task creator do not try to break the agent :-(
-                                if ssh and not info.enable_network:
-                                    self._logger.error("Exception: ssh for student requires internet access in the task %s",info.job_id)
-                                    self._create_safe_task(self.handle_job_closing(info.container_id, -1, manual_feedback="ssh for student requires internet access in the task configuration !"))
+                                if ssh and not (info.enable_network and info.ssh_allowed):
+                                    self._logger.error("Exception: ssh for student requires to allow ssh and internet access in the task %s environment configuration tab",info.job_id)
+                                    self._create_safe_task(self.handle_job_closing(info.container_id, -1, manual_feedback="ssh for student requires to allow ssh and internet access in the task environment configuration tab!"))
                                 else:
                                     self._create_safe_task(self.create_student_container(info, socket_id, environment, memory_limit,
                                                                                      time_limit, hard_time_limit, share_network,

--- a/inginious/backend/backend.py
+++ b/inginious/backend/backend.py
@@ -21,7 +21,7 @@ from inginious.common.messages import BackendNewJob, AgentJobStarted, AgentJobDo
 WaitingJob = namedtuple('WaitingJob', ['priority', 'time_received', 'client_addr', 'job_id', 'msg'])
 RunningJob = namedtuple('RunningJob', ['agent_addr', 'client_addr', 'msg', 'time_started'])
 EnvironmentInfo = namedtuple('EnvironmentInfo', ['last_id', 'created_last', 'agents', 'type'])
-AgentInfo = namedtuple('AgentInfo', ['name', 'environments'])  # environments is a list of tuple (type, environment)
+AgentInfo = namedtuple('AgentInfo', ['name', 'environments', 'ssh_allowed'])  # environments is a list of tuple (type, environment)
 
 class Backend(object):
     """
@@ -194,7 +194,7 @@ class Backend(object):
                 job = None
                 while job is None:
                     # keep the object, do not unzip it directly! It's sometimes modified when a job is killed.
-                    job = self._waiting_jobs_pq.get(self._registered_agents[agent_addr].environments)
+                    job = self._waiting_jobs_pq.get(self._registered_agents[agent_addr])
                     priority, insert_time, client_addr, job_id, job_msg = job
 
                     # Killed job, removing it from the mapping
@@ -232,7 +232,7 @@ class Backend(object):
 
         self._registered_agents[agent_addr] = AgentInfo(message.friendly_name,
                                                         [(etype, env) for etype, envs in
-                                                         message.available_environments.items() for env in envs])
+                                                         message.available_environments.items() for env in envs], message.ssh_allowed)
         self._available_agents.extend([agent_addr for _ in range(0, message.available_job_slots)])
         self._ping_count[agent_addr] = 0
 

--- a/inginious/backend/topic_priority_queue.py
+++ b/inginious/backend/topic_priority_queue.py
@@ -36,10 +36,11 @@ class TopicPriorityQueue:
         :return: the smallest elements that fits in one of the topics
         :raises: queue.Empty exception if the queue has no elements that fits in any of the topics
         """
+        agent_ssh = topics.ssh_allowed
         best_topic = None
         best_elem = None
-        for topic in topics:
-            if topic in self.queues and len(self.queues[topic]) != 0 and (best_elem is None or best_elem > self.queues[topic][0]):
+        for topic in topics.environments:
+            if topic in self.queues and len(self.queues[topic]) != 0 and (best_elem is None or best_elem > self.queues[topic][0]) and (agent_ssh or not self.queues[topic][0].msg.environment_parameters["ssh_allowed"]):
                 best_topic = topic
                 best_elem = self.queues[topic][0]
         if best_topic is None:

--- a/inginious/common/messages.py
+++ b/inginious/common/messages.py
@@ -177,6 +177,7 @@ class AgentHello:
     friendly_name: str  # a string containing a friendly name to identify agent
     available_job_slots: int  # an integer giving the number of concurrent
     available_environments: Dict[str, Dict[str, Dict[str, Any]]]  # dict of available environments:
+    ssh_allowed: bool
     # {
     #     "type": {
     #         "name": {                 #  for example, "default"

--- a/inginious/frontend/arch_helper.py
+++ b/inginious/frontend/arch_helper.py
@@ -90,7 +90,7 @@ def create_arch(configuration, tasks_fs, context, course_factory):
 
         client = Client(context, "inproc://backend_client")
         backend = Backend(context, "inproc://backend_agent", "inproc://backend_client")
-        agent_docker = DockerAgent(context, "inproc://backend_agent", "Docker - Local agent", concurrency, tasks_fs, debug_host, debug_ports, tmp_dir)
+        agent_docker = DockerAgent(context, "inproc://backend_agent", "Docker - Local agent", concurrency, tasks_fs, debug_host, debug_ports, tmp_dir, ssh_allowed=True)
         agent_mcq = MCQAgent(context, "inproc://backend_agent", "MCQ - Local agent", 1, tasks_fs, course_factory.get_task_factory().get_problem_types())
 
         asyncio.ensure_future(_restart_on_cancel(logger, agent_docker))

--- a/inginious/frontend/environment_types/generic_docker_oci_runtime.py
+++ b/inginious/frontend/environment_types/generic_docker_oci_runtime.py
@@ -28,6 +28,9 @@ class GenericDockerOCIRuntime(FrontendEnvType):
         # Network access in grading container?
         out["network_grading"] = data.get("network_grading", False)
 
+        # SSH allowed ?
+        out["ssh_allowed"] = data.get("ssh_allowed", False)
+
         # Limits
         limits = {"time": 20, "memory": 1024, "disk": 1024}
         if "limits" in data:

--- a/inginious/frontend/templates/course_admin/edit_tabs/env_generic_docker_oci.html
+++ b/inginious/frontend/templates/course_admin/edit_tabs/env_generic_docker_oci.html
@@ -31,6 +31,17 @@
     </div>
 </div>
 <div class="form-group row">
+    <label for="{{env_id}}-ssh-allowed" class="col-sm-4 control-label">{{ _("Allow ssh?") }}</label>
+
+    <div class="col-sm-8">
+        <div class="checkbox"><label>
+            <input type="checkbox" id="{{env_id}}-ssh-allowed" name="envparams[{{env_id}}][ssh_allowed]"
+                   {{'checked="checked"' if env_params.get('ssh_allowed',False) }} />&nbsp;
+        </label></div>
+    </div>
+</div>
+
+<div class="form-group row">
     <label for="{{env_id}}-run-cmd" class="col-sm-4 control-label">{{ _("Custom command to be run in container <small>(instead of running the run script)</small>") | safe}}</label>
 
     <div class="col-sm-8">


### PR DESCRIPTION
Added a checkbox in the environment configuration tab to inform that the task will use ssh.
Such tasks will only be handled by agents with the specific flag ("ssh_allowed").
This means, if multiple ssh tasks are running, it would only block the ssh_allowed agents and not the other ones.

DockerAgent has now a new argument, ssh_allowed: bool

Doc was also slightly updated.