### PR TITLE
LocalFSProvider: remove slash addition in from_subfolder

### DIFF
--- a/inginious/common/filesystems/local.py
+++ b/inginious/common/filesystems/local.py
@@ -36,7 +36,7 @@ class LocalFSProvider(FileSystemProvider):
 
     def from_subfolder(self, subfolder):
         self._checkpath(subfolder)
-        return LocalFSProvider(self.prefix + "/" + subfolder)
+        return LocalFSProvider(self.prefix + subfolder)
 
     def exists(self, path=None):
         if path is None:


### PR DESCRIPTION
Adding a trailing slash at the end of the parent prefix is not required since the \_\_init\_\_ method of the parent LocalFSProvider already did it.

https://github.com/UCL-INGI/INGInious/blob/8d49326d6e73ce887519dff518735d709c099685/inginious/common/filesystems/provider.py#L35-L39