### PR TITLE
Fix denial of service by job deletion

### DIFF
--- a/inginious/backend/backend.py
+++ b/inginious/backend/backend.py
@@ -173,12 +173,8 @@ class Backend(object):
 
         #jobs_waiting: a list of tuples in the form
         #(job_id, is_current_client_job, info, launcher, max_time)
-        jobs_waiting = list()
-
-        for job in self._waiting_jobs.values():
-            if isinstance(job.msg, ClientNewJob):
-                jobs_waiting.append((job.job_id, job.client_addr == client_addr, job.msg.course_id+"/"+job.msg.task_id, job.msg.launcher,
-                                     self._get_time_limit_estimate(job.msg)))
+        jobs_waiting = [(job.job_id, job.client_addr == client_addr, job.msg.course_id+"/"+job.msg.task_id, job.msg.launcher,
+                                     self._get_time_limit_estimate(job.msg)) for job in self._waiting_jobs.values()]
 
         await ZMQUtils.send_with_addr(self._client_socket, client_addr, BackendGetQueue(jobs_running, jobs_waiting))
 

--- a/inginious/backend/backend.py
+++ b/inginious/backend/backend.py
@@ -144,11 +144,10 @@ class Backend(object):
 
     async def handle_client_kill_job(self, client_addr, message: ClientKillJob):
         """ Handle an ClientKillJob message. Remove a job from the waiting list or send the kill message to the right agent. """
-        # Check if the job is not in the queue
+        # Check if the job is not in the waiting list
         if message.job_id in self._waiting_jobs:
-            # Erase the job reference in priority queue
-            job = self._waiting_jobs.pop(message.job_id)
-            job._replace(msg=None)
+            # Erase the job in waiting list
+            del self._waiting_jobs[message.job_id]
 
             # Do not forget to send a JobDone
             await ZMQUtils.send_with_addr(self._client_socket, client_addr, BackendJobDone(message.job_id, ("killed", "You killed the job"),
@@ -206,9 +205,8 @@ class Backend(object):
                     job = self._waiting_jobs_pq.get(topics)
                     priority, insert_time, client_addr, job_id, job_msg = job
 
-                    # Killed job, removing it from the mapping
-                    if not job_msg:
-                        del self._waiting_jobs[job_id]
+                    # Ensure the job has not been removed (killed)
+                    if job_id not in self._waiting_jobs:
                         job = None  # repeat the while loop. we need a job
             except queue.Empty:
                 continue  # skip agent, nothing to do!


### PR DESCRIPTION
Namedtuple ``_replace`` function returns a new instance. Therefore, ``job.msg`` is never set to ``None`` is the waiting list, resulting in exceptions during the queue update after reserving an agent execution slot, never releasing it. The only way to recover is to restart the backend, or, in the best case, the agent.

This proposes a fix that directly removes the job from the waiting list and check if it's still there after popping the job id from the priority queue.