### PR TITLE
[installer] Fix failure due to pymongo bump

### DIFF
--- a/inginious/frontend/installer.py
+++ b/inginious/frontend/installer.py
@@ -335,7 +335,7 @@ class Installer:
         database_name = "INGInious"
 
         should_ask = True
-        if self.try_mongodb_opts(host, database_name):
+        if self.try_mongodb_opts(host, database_name) is not None:
             should_ask = self._ask_boolean(
                 "Successfully connected to MongoDB. Do you want to edit the configuration anyway?", False)
         else:


### PR DESCRIPTION
Pymongo 4.0+ introduced a new way to compare with database objects (see https://github.com/mongodb/mongo-python-driver/pull/728/files#diff-fea5af5b145e4376d3484eb5d647c0fd219bad8f07af1bae72de75ae3c1eba08).

This produces the following error in the "inginious-install" script:
```
Traceback (most recent call last):
  File "./inginious-install", line 19, in <module>
    inginious.frontend.installer.Installer(args.file).run()
  File "/inginious/inginious/frontend/installer.py", line 148, in run
    mongo_opt = self.configure_mongodb()
  File "/inginious/inginious/frontend/installer.py", line 338, in configure_mongodb
    if self.try_mongodb_opts(host, database_name):
  File "/home/vagrant/.local/lib/python3.8/site-packages/pymongo/database.py", line 829, in __bool__
    raise NotImplementedError("Database objects do not implement truth "
NotImplementedError: Database objects do not implement truth value testing or bool(). Please compare with None instead: database is not None
```