### PR TITLE
[tests/filesystems] Add tests and refactor fixtures

### DIFF
--- a/inginious/common/filesystems/__init__.py
+++ b/inginious/common/filesystems/__init__.py
@@ -136,7 +136,7 @@ class FileSystemProvider(metaclass=ABCMeta):
     @abstractmethod
     def distribute(self, filepath, allow_folders=True):
         """ Give information on how to distribute a file. Provides Zip files of folders. Can return:
-            ("file", mimetype, fileobj) where fileobj is an object-like file (with read()) and mimetype its mime-type.
+            ("local", mimetype, fileobj) where fileobj is an object-like file (with read()) and mimetype its mime-type.
             ("url", None, url) where url is a url to a distant server which possess the file.
             ("invalid", None, None) if the file cannot be distributed
         """


### PR DESCRIPTION
- Add tests for:
  - move()
  - get_last_modification_time()
  - get()
  - put()
  - get_needed_args()
  - init_from_args()
  - copy_to()

- Refactor fixtures:
  copy_{to,from}() requires files on the disk, outside of the FSProvider prefix.  In order to avoid redundancy in the fixtures, factories are introduced as well as  specialized fixtures.
  Some tests case are also parametrized to avoid test code duplication.