### PR TITLE
[containers/run_student] Keep std file descriptors open in wait_until_finished

### DIFF
--- a/base-containers/base/inginious_container_api/run_student.py
+++ b/base-containers/base/inginious_container_api/run_student.py
@@ -258,8 +258,8 @@ def wait_until_finished(both_dockers, zmq_socket, stdin, stdout, stderr, student
     # handle the student_container outputs and wait for final message
     message = None
     msg_type = None
-    stdout_file = os.fdopen(stdout, 'wb')
-    stderr_file = os.fdopen(stderr, 'wb')
+    stdout_file = os.fdopen(stdout, 'wb', closefd=False)
+    stderr_file = os.fdopen(stderr, 'wb', closefd=False)
 
     while msg_type != "run_student_retval":
         zmq_socket.send(msgpack.dumps({"type": "dummy_message"}, use_bin_type=True))  # ping pong socket


### PR DESCRIPTION
``run_student`` behaviour has changed in PR #700 so that the current ``wait_until_finished`` function wraps a file around stdout and sdterr file descriptors. However, by default, when the file is deallocated at the end of the function, the file descriptor is also closed.

This leads to a ``Bad file descriptor`` errors when ``run_student_simple`` closes its pipe (https://github.com/UCL-INGI/INGInious/blob/master/base-containers/base/inginious_container_api/run_student.py#L134) as its ``std_out_w`` has been closed in the meantime :

      sendmsg(21, {msg_name=NULL, msg_namelen=0, msg_iov=[{iov_base="S", iov_len=1}], msg_iovlen=1, msg_control=[{cmsg_len=28, cmsg_level=SOL_SOCKET, cmsg_type=SCM_RIGHTS, cmsg_data=[7, 4, 6]}], msg_controllen=32, msg_flags=0}, 0) = 1
      sendto(21, "\207\244type\263run_student_command\264stude"..., 176, 0, NULL, 0) = 176
      ...
      close(4)                                = 0
      close(6)                                = 0
      unlink("/sockets/pk0kr_xc4.sock")       = 0
      unlink("/sockets/pk0kr_xc4")            = 0
      ...
      fstat(4, 0x7ffde994ac80)                = -1 EBADF (Bad file descriptor)
      write(2, "Traceback (most recent call last"..., 35Traceback (most recent call last):
      ) = 35

The fix adds ``closefd=False`` to ``fdopen`` calls to avoid the file descriptors to be closed when the file object is closed and restores the previous behaviour:

      sendmsg(17, {msg_name=NULL, msg_namelen=0, msg_iov=[{iov_base="S", iov_len=1}], msg_iovlen=1, msg_control=[{cmsg_len=28, cmsg_level=SOL_SOCKET, cmsg_type=SCM_RIGHTS, cmsg_data=[7, 4, 6]}], msg_controllen=32, msg_flags=0}, 0) = 1
      sendto(17, "\207\244type\263run_student_command\264stude"..., 176, 0, NULL, 0) = 176
      ...
      unlink("/sockets/p7nvyyjbi.sock")       = 0
      unlink("/sockets/p7nvyyjbi")            = 0
      ...
      fstat(4, {st_mode=S_IFIFO|0600, st_size=0, ...}) = 0
      ...
      close(4)                                = 0
      ...
      close(6)                                = 0

It seems good practice to keep the closing of the std descriptors outside of the ``run_student`` function as they must be first opened to be passed as arguments.