### PR TITLE
[backend] do not erase previous state in case of errors

### DIFF
--- a/inginious/agent/docker_agent/__init__.py
+++ b/inginious/agent/docker_agent/__init__.py
@@ -866,7 +866,7 @@ class DockerAgent(Agent):
             custom = {}
             tests = {}
             archive = None
-            state = ""
+            state = info.inputdata.get("@state", "")  # init state to previous state
 
             if killed is not None:
                 result = killed
@@ -959,7 +959,7 @@ class DockerAgent(Agent):
                 self._logger.warning("Cannot kill container for job %s because it is not running", str(message.job_id))
                 # Ensure the backend/frontend receive the info that the job is done. This will be ignored in the worst
                 # case.
-                await self.send_job_result(message.job_id, "killed")
+                await self.send_job_result(message.job_id, "killed", state=message.state)
         except asyncio.CancelledError:
             raise
         except:

--- a/inginious/agent/mcq_agent/__init__.py
+++ b/inginious/agent/mcq_agent/__init__.py
@@ -72,6 +72,7 @@ class MCQAgent(Agent):
 
     async def new_job(self, msg: BackendNewJob):
         language = msg.inputdata.get("@lang", "")
+        previous_state = msg.inputdata.get("@state", "")
         translation = self._translations.get(language, gettext.NullTranslations())
         # TODO: this would probably require a refactor.
         # This may pose problem with apps that start multiple MCQAgents in the same process...
@@ -124,7 +125,7 @@ class MCQAgent(Agent):
         if nb_subproblems == 0:
             grade = 0.0
             text.append("No subproblems defined")
-            await self.send_job_result(msg.job_id, "crashed", "\n".join(text), grade, problems, {}, {}, "", None)
+            await self.send_job_result(msg.job_id, "crashed", "\n".join(text), grade, problems, {}, {}, previous_state, None)
         else:
             grade = 100.0 * float(nb_subproblems - error_count) / float(nb_subproblems)
             await self.send_job_result(msg.job_id, ("success" if result else "failed"), "\n".join(text), grade, problems, {}, {}, state, None)

--- a/inginious/common/messages.py
+++ b/inginious/common/messages.py
@@ -162,6 +162,7 @@ class BackendNewJob:
 class BackendKillJob:
     """ Kills a running job. """
     job_id: BackendJobId  # the backend-side job id that is associated to the job to kill
+    state: str  # submission state in case the job is lost at the agent
 
 
 #################################################################


### PR DESCRIPTION
The fix for #743  is done at the agent level, as it is not easy to know if the previous state has to be used at the queue level based on the received information as the state can legitimately be empty.