### PR TITLE
File extensions must be separated by commas

### DIFF
--- a/inginious/frontend/templates/course_admin/subproblems/file.html
+++ b/inginious/frontend/templates/course_admin/subproblems/file.html
@@ -8,7 +8,7 @@
     </div>
 </div>
 <div class="form-group row">
-    <label for="extensions-PID" class="col-sm-2 control-label">{{ _("Allowed file extensions (including the dot, separated by spaces)") }}</label>
+    <label for="extensions-PID" class="col-sm-2 control-label">{{ _("Allowed file extensions (including the dot, separated by commas)") }}</label>
     <div class="col-sm-10">
         <input type="text" class="form-control" id="extensions-PID" name="problem[PID][allowed_exts]" placeholder=".txt,.zip,.gz"/>
     </div>


### PR DESCRIPTION
Apparently space do not work, extensions must be separated by commas (which is more usual. Am I the only one to follow the doc? :p)