### PR TITLE
[backend] BackendJobDone should be sent to the waiting job initiating client

### DIFF
--- a/inginious/backend/backend.py
+++ b/inginious/backend/backend.py
@@ -150,9 +150,9 @@ class Backend(object):
             waiting_job = self._waiting_jobs.pop(message.job_id)
             previous_state = waiting_job.msg.inputdata.get("@state", "")
 
-            # Do not forget to send a JobDone
-            await ZMQUtils.send_with_addr(self._client_socket, client_addr, BackendJobDone(message.job_id, ("killed", "You killed the job"),
-                                                                                           0.0, {}, {}, {}, previous_state, None, "", ""))
+            # Do not forget to send a JobDone to the initiating client
+            await ZMQUtils.send_with_addr(self._client_socket, waiting_job.client_addr, BackendJobDone(
+                message.job_id, ("killed", "You killed the job"), 0.0, {}, {}, {}, previous_state, None, "", ""))
         # If the job is running, transmit the info to the agent
         elif message.job_id in self._job_running:
             running_job = self._job_running[message.job_id]


### PR DESCRIPTION
**Describe the bug**
In database-shared multi-client (multiprocess) setup, another client can kill a waiting job it does not own and receive a JobDone it cannot process. This PR aims at fixing this by sending the message to the initiating client.

**INGInious installation details**
- Version: v0.5+

**To Reproduce**
Steps to reproduce the behavior:
1. Deploy webapp, queue and agent with `concurrency=1` separately.
2. Deploy a second webapp using the same configuration file.
3. Submit a long processing job (sleep for instance) so that the agent gets busy.
4. In the meantime, submit a job for another task so that a job is in the waiting list.
5. Kill that job from the second webapp instance, you'll get something like:

        Traceback (most recent call last):
        File ".../inginious/client/_zeromq_client.py", line 230, in _run_socket
           raise Exception("Received message %s for an unknown transaction %s", msg_class, key)
        Exception: ('Received message %s for an unknown transaction %s', <class 'inginious.common.messages.BackendJobDone'>, 'db1b6f33-b82e-4298-b5d3-d518b1d28134')

**Expected behavior**
The job gets killed correctly and data get wiped from the appropriate client.
