### PR TITLE
Update installation.rst

### DIFF
--- a/doc/admin_doc/install_doc/installation.rst
+++ b/doc/admin_doc/install_doc/installation.rst
@@ -106,7 +106,7 @@ Then, Mongo:
 .. code-block:: bash
 
     wget -qO - https://www.mongodb.org/static/pgp/server-6.0.asc | sudo apt-key add -
-    echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/6.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-6.0.list
+    echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-6.0.list
     sudo apt update
     wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb
     sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2_amd64.deb


### PR DESCRIPTION
the documentation targets Ubuntu 22.04 but the installation of Mongo refers to ubuntu focal (20.04).