### PR TITLE
[docker_agent] fix container timestamp for docker 23+

### DIFF
--- a/inginious/agent/docker_agent/_docker_interface.py
+++ b/inginious/agent/docker_agent/_docker_interface.py
@@ -57,7 +57,7 @@ class DockerInterface(object):  # pragma: no cover
             title = None
             try:
                 title = x.labels["org.inginious.grading.name"]
-                created = datetime.strptime(x.attrs['Created'][:-4], "%Y-%m-%dT%H:%M:%S.%f").timestamp()
+                created = x.history()[0]['Created']
                 ports = [int(y) for y in x.labels["org.inginious.grading.ports"].split(
                     ",")] if "org.inginious.grading.ports" in x.labels else []
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import os
 from setuptools import setup, find_packages
 
 install_requires = [
-    "docker>=2.5.0",
+    "docker>=3.0",
     "docutils>=0.14",
     "pymongo>=3.2.2",
     "PyYAML>=3.11",


### PR DESCRIPTION
Since Docker 23, container image creation date seem to include the timezone. Moreover, previous creation date strings remain unchanged. Example :

    >>> for im in client.images.list():
    ...     print(im.attrs["Created"])
    ...
    2023-02-23T09:34:58.109950958+01:00
    2023-02-23T09:34:58.109950958+01:00
    2023-02-02T05:09:14.349840104Z
    2022-05-12T18:22:55.007415828Z
    2022-03-15T22:20:23.996544531Z
    2021-09-15T18:20:23.99863383Z

This breaks current code which removes the last 4 chars. Complete isodate support in Python is too recent (3.11) to replace it by ``datetime.fromisoformat``. Another quick solution is to take the 26 first chars.

However, the docker API includes since v3.0 a `history()` function that returns image layers creation time using a timestamp directly. The first one always seems to be the equivalent image creation date.