### PR TITLE
[agent_docker] add support for nvidia runtime

### DIFF
--- a/doc/admin_doc/install_doc/create_container.rst
+++ b/doc/admin_doc/install_doc/create_container.rst
@@ -28,7 +28,7 @@ Here is an example of Dockerfile:
    RUN echo 'run_types["php"] = "/bin/php"' >> /usr/lib/python3.6/site-packages/inginious_container_api/run_types.py
 
 As easily seen, this Dockerfile creates a new container image that can launch PHP scripts.
-The syntax of these Dockerfiles is extensively described on the website of Docker_, 
+The syntax of these Dockerfiles is extensively described on the website of Docker_,
 but we will detail here the most important things to know.
 
 Each Dockerfile used on INGInious should begin with ```FROM inginious/ingi-c-base``` and
@@ -93,6 +93,7 @@ You can also enter directly in the container image to test it in the command lin
 It is also easy to rebuild the initially provided containers images.
 If you have a proper INGInious version installed, no need for building images, you can re-download the provided images by simply running:
 ::
+
     $ inginious-container-update
 
 If you are running on a dev environment (cloned from the repository), from the main directory, enter the following commands to take into consideration your local files:
@@ -105,6 +106,115 @@ If you are running on a dev environment (cloned from the repository), from the m
 
 Note, this manual building step should not be necessary for a teacher.
 Of course, if you rebuilt your images, you will have to restart inginious-webapp.
+
+Leveraging other runtimes
+-------------------------
+
+INGInious relies on the Docker API to run containers. Docker default OCI runtime is *runc* and will typically meet
+all your needs. However, you may want, for very specific tasks, leverage some features that are not supported by
+*runc*. This is, for instance, the case of rooted containers, so that the student can perform root operations, or
+the case of GPU-enabled containers.
+
+INGInious currently supports the following OCI runtimes : *runc*, *crun*, *kata-runtime v1.x*, *nvidia-container*.
+
+crun
+````
+`crun <https://github.com/containers/crun>`_ is a *runc*-like runtime but implemented in C instead of Go.
+It generally provides you with better performance.
+
+To activate *crun*, download the prebuilt binary from the project page and put it or symlink it to `/usr/bin/crun`.
+Then, modify your ``/etc/docker/daemon.json`` file in order to add *crun* as a runtime, and set it as `default-runtime`
+to make INGInious use it by default.
+
+::
+
+ {
+    "default-runtime": "crun",
+    "runtimes": {
+        "crun": {
+            "path": "/usr/bin/crun"
+        }
+    }
+ }
+
+Restart Docker and your INGInious agent.
+
+Kata
+````
+`Kata <https://github.com/kata-containers/runtime>`_ actually runs lightweight virtual machines instead of containers,
+to provide isolation and security advantages of VMs.
+
+INGInious allows you to start rooted containers using Kata runtime. This allows you to provide root SSH access to the
+students to make them perform administrator operations. The `run_student` container architecture protects your grading
+files as only the `/task/student` folder is R/W in the student container.
+
+To activate *kata*, download the prebuilt binaries from the project page or install the runtime from the appropriate
+distribution repositories. Then, modify your ``/etc/docker/daemon.json`` file in order to add *kata-runtime* as a runtime.
+
+::
+
+ {
+    "runtimes": {
+        "kata-runtime": {
+            "path": "/usr/bin/kata-runtime"
+        }
+    }
+ }
+
+Restart Docker and your INGInious agent. You will be able to run rooted containers by selecting *Kata* as the task
+environment type. To restrict container availability to *Kata*, add the following label to your `Dockerfile`:
+
+::
+
+  LABEL org.inginious.grading.need_root=1
+
+NVIDIA
+``````
+
+The `NVIDIA <https://github.com/NVIDIA/nvidia-container-runtime>`_ runtime is built upon *runc* and allows you to leverage
+the host GPUs inside containers by exposing the device inside the container filesystem. It can be useful in case
+you want to perform CUDA-powered computations or generating graphics, ...
+
+To activate *nvidia* as runtime, you need to :
+
+#. Install the nvidia driver and cuda toolkit. Repositories and instructions are provided on the
+   `NVIDIA website <https://developer.nvidia.com/cuda-downloads>`_.
+#. Install the cuda-container-toolkit. Repositories and instructions are provided in the
+   `NVIDIA install guide <https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html>`_.
+
+Then, modify your ``/etc/docker/daemon.json`` file in order to add *nvidia* as a runtime.
+
+::
+
+ {
+    "runtimes": {
+        "nvidia": {
+            "path": "/usr/bin/nvidia-container-runtime"
+        }
+    }
+ }
+
+Restart Docker and your INGInious agent. You will be able to run GPU-enabled containers by selecting *NVIDIA* as the task
+environment type.
+
+.. WARNING::
+
+    To expose the GPU inside the container, the NVIDIA runtime still requires you to set the following environment variables in your ``Dockerfile``:
+    ::
+
+       ENV NVIDIA_VISIBLE_DEVICES all
+       ENV NVIDIA_DRIVER_CAPABILITIES compute,utility
+
+    Details on these environment variables are provided in the
+    `NVIDIA user guide <https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html>`_.
+    You'll then need the appropriate libraries installed. You may probably want to base the INGInious containers on
+    the ``nvidia/cuda:x.y.z-base-rockylinux8`` `CUDA container <https://gitlab.com/nvidia/container-images/cuda>`_.
+
+To restrict container availability to *NVIDIA* (recommended), add the following label to your `Dockerfile`:
+
+::
+
+  LABEL org.inginious.grading.need_gpu=1
 
 Share what you created
 ----------------------

--- a/inginious/agent/docker_agent/__init__.py
+++ b/inginious/agent/docker_agent/__init__.py
@@ -980,9 +980,10 @@ class DockerAgent(Agent):
 
     def _detect_runtimes(self) -> Dict[str, DockerRuntime]:
         heuristic = [
-            ("runc", lambda x: DockerRuntime(runtime=x, run_as_root=False, shared_kernel=True, envtype="docker")),
-            ("crun", lambda x: DockerRuntime(runtime=x, run_as_root=False, shared_kernel=True, envtype="docker")),
-            ("kata", lambda x: DockerRuntime(runtime=x, run_as_root=True, shared_kernel=False, envtype="kata")),
+            ("runc", lambda x: DockerRuntime(runtime=x, run_as_root=False, enables_gpu=False, shared_kernel=True, envtype="docker")),
+            ("crun", lambda x: DockerRuntime(runtime=x, run_as_root=False, enables_gpu=False, shared_kernel=True, envtype="docker")),
+            ("kata", lambda x: DockerRuntime(runtime=x, run_as_root=True, enables_gpu=False, shared_kernel=False, envtype="kata")),
+            ("nvidia", lambda x: DockerRuntime(runtime=x, run_as_root=False, enables_gpu=True, shared_kernel=True, envtype="nvidia"))
         ]
         retval = {}
 

--- a/inginious/agent/docker_agent/_docker_interface.py
+++ b/inginious/agent/docker_agent/_docker_interface.py
@@ -62,21 +62,25 @@ class DockerInterface(object):  # pragma: no cover
                     ",")] if "org.inginious.grading.ports" in x.labels else []
 
                 for docker_runtime in runtimes:
-                    if docker_runtime.run_as_root or "org.inginious.grading.need_root" not in x.labels:
-                        logger.info("Envtype %s (%s) can use container %s", docker_runtime.envtype, docker_runtime.runtime, title)
-                        if x.labels.get("org.inginious.grading.agent_version") != str(DOCKER_AGENT_VERSION):
-                            logger.warning(
-                                "Container %s is made for an old/newer version of the agent (container version is "
-                                "%s, but it should be %i). INGInious will ignore the container.", title,
-                                str(x.labels.get("org.inginious.grading.agent_version")), DOCKER_AGENT_VERSION)
-                            continue
+                    if "org.inginious.grading.need_root" in x.labels and not docker_runtime.run_as_root:
+                        continue
+                    if "org.inginious.grading.need_gpu" in x.labels and not docker_runtime.enables_gpu:
+                        continue
 
-                        images[docker_runtime.envtype][x.attrs['Id']] = {
-                            "title": title,
-                            "created": created,
-                            "ports": ports,
-                            "runtime": docker_runtime.runtime
-                        }
+                    logger.info("Envtype %s (%s) can use container %s", docker_runtime.envtype, docker_runtime.runtime, title)
+                    if x.labels.get("org.inginious.grading.agent_version") != str(DOCKER_AGENT_VERSION):
+                        logger.warning(
+                            "Container %s is made for an old/newer version of the agent (container version is "
+                            "%s, but it should be %i). INGInious will ignore the container.", title,
+                            str(x.labels.get("org.inginious.grading.agent_version")), DOCKER_AGENT_VERSION)
+                        continue
+
+                    images[docker_runtime.envtype][x.attrs['Id']] = {
+                        "title": title,
+                        "created": created,
+                        "ports": ports,
+                        "runtime": docker_runtime.runtime
+                    }
             except:
                 logging.getLogger("inginious.agent").exception("Container %s is badly formatted", title or "[cannot load title]")
 

--- a/inginious/agent/docker_agent/_docker_runtime.py
+++ b/inginious/agent/docker_agent/_docker_runtime.py
@@ -9,6 +9,7 @@ class DockerRuntime(NamedTuple):
     """
     runtime: str  # runtime name (as set in the configuration of Docker)
     run_as_root: bool  # indicates whether the runtime runs the container as root or not. Should always be False if shared_kernel is True
+    enables_gpu: bool  # indicates whether the runtime enables the usage of GPU or not.
     shared_kernel: bool  # indicates whether the containers running on this runtime share the host kernel
     envtype: str  # environment type to be returned to the backend/client (for example, "docker" or "kata")
                   # the envtype must be unique in the same DockerAgent.

--- a/inginious/frontend/environment_types/__init__.py
+++ b/inginious/frontend/environment_types/__init__.py
@@ -3,6 +3,7 @@ import abc
 from inginious.frontend.environment_types.docker import DockerEnvType
 from inginious.frontend.environment_types.kata import KataEnvType
 from inginious.frontend.environment_types.mcq import MCQEnvType
+from inginious.frontend.environment_types.nvidia import NvidiaEnvType
 
 __env_types = {}
 
@@ -24,7 +25,6 @@ def register_env_type(env_obj):
 def register_base_env_types():
     # register standard env types here
     register_env_type(DockerEnvType())
+    register_env_type(NvidiaEnvType())
     register_env_type(KataEnvType())
     register_env_type(MCQEnvType())
-
-

--- a/inginious/frontend/environment_types/nvidia.py
+++ b/inginious/frontend/environment_types/nvidia.py
@@ -1,0 +1,11 @@
+from inginious.frontend.environment_types.generic_docker_oci_runtime import GenericDockerOCIRuntime
+
+
+class NvidiaEnvType(GenericDockerOCIRuntime):
+    @property
+    def id(self):
+        return "nvidia"
+
+    @property
+    def name(self):
+        return _("Container with GPUs (NVIDIA)")


### PR DESCRIPTION
This PRs adds support for the NVIDIA runtime to leverage GPU usage. This implementation as a seperate runtime was prefered over a GPU option in the environment config for the following reasons : 
- ``--gpus``, or its docker-py equivalent 

         device_requests=[docker.types.DeviceRequest(count=-1, capabilities=[['gpu']])]
   automatically selects the nvidia runtime as it provides the capability but will fails with a `500` error in the Docker API if the runtime is not available, exception which is hard to catch using docker-py.
- There is no docker-py API (or even Docker API ?) to know the capabilities of a runtime to prevent such an error.
- The GPU opt-in would have to be shown only for compatible runtimes (Kata, for instance, would not support it)
- It is actually really more lightweight to implement and not less a generic implementation as only NVIDIA GPUs are currently supported by the Docker ``--gpus`` argument.

An additional label is introduced to restrict usage of a Docker image to the nvidia environment type only.

As mentioned in the provided documentation, the `nvidia/cuda:x.y.z-base-rockylinux8` works in replacement of `rockylinux:8` as base for the `ingi/inginious-c-base` container. This was not included in this PR yet as it would require some practical usage tests to evaluate how accurate it would be.