### PR TITLE
[agent/docker] replace SSH opt-in by env types

### DIFF
--- a/inginious/agent/__init__.py
+++ b/inginious/agent/__init__.py
@@ -48,7 +48,7 @@ class Agent(object, metaclass=ABCMeta):
     An INGInious agent, that grades specific kinds of jobs, and interacts with a Backend.
     """
 
-    def __init__(self, context, backend_addr, friendly_name, concurrency, filesystem, ssh_allowed=False):
+    def __init__(self, context, backend_addr, friendly_name, concurrency, filesystem):
         """
         :param context: a ZMQ context to which the agent will be linked
         :param backend_addr: address of the backend to which the agent should connect. The format is the same as ZMQ
@@ -66,7 +66,6 @@ class Agent(object, metaclass=ABCMeta):
         self.__backend_addr = backend_addr
         self.__context = context
         self.__friendly_name = friendly_name
-        self.__ssh_allowed = ssh_allowed
         self.__backend_socket = self.__context.socket(zmq.DEALER)
         self.__backend_socket.ipv6 = True
 
@@ -112,7 +111,7 @@ class Agent(object, metaclass=ABCMeta):
 
         # Tell the backend we are up and have `concurrency` threads available
         self._logger.info("Saying hello to the backend")
-        await ZMQUtils.send(self.__backend_socket, AgentHello(self.__friendly_name, self.__concurrency, self.environments, self.__ssh_allowed))
+        await ZMQUtils.send(self.__backend_socket, AgentHello(self.__friendly_name, self.__concurrency, self.environments))
         self.__backend_last_seen_time = time.time()
 
         run_listen = self._loop.create_task(self.__run_listen())

--- a/inginious/common/messages.py
+++ b/inginious/common/messages.py
@@ -178,7 +178,6 @@ class AgentHello:
     friendly_name: str  # a string containing a friendly name to identify agent
     available_job_slots: int  # an integer giving the number of concurrent
     available_environments: Dict[str, Dict[str, Dict[str, Any]]]  # dict of available environments:
-    ssh_allowed: bool
     # {
     #     "type": {
     #         "name": {                 #  for example, "default"

--- a/inginious/frontend/environment_types/__init__.py
+++ b/inginious/frontend/environment_types/__init__.py
@@ -25,6 +25,9 @@ def register_env_type(env_obj):
 def register_base_env_types():
     # register standard env types here
     register_env_type(DockerEnvType())
+    register_env_type(DockerEnvType(ssh_allowed=True))
     register_env_type(NvidiaEnvType())
+    register_env_type(NvidiaEnvType(ssh_allowed=True))
     register_env_type(KataEnvType())
+    register_env_type(KataEnvType(ssh_allowed=True))
     register_env_type(MCQEnvType())

--- a/inginious/frontend/environment_types/docker.py
+++ b/inginious/frontend/environment_types/docker.py
@@ -5,8 +5,8 @@ from inginious.frontend.environment_types.generic_docker_oci_runtime import Gene
 class DockerEnvType(GenericDockerOCIRuntime):
     @property
     def id(self):
-        return "docker"
+        return "docker-ssh" if self._ssh_allowed else "docker"
 
     @property
     def name(self):
-        return _("Standard container (Docker)")
+        return _("Standard container + SSH") if self._ssh_allowed else _("Standard container")

--- a/inginious/frontend/environment_types/generic_docker_oci_runtime.py
+++ b/inginious/frontend/environment_types/generic_docker_oci_runtime.py
@@ -28,11 +28,6 @@ class GenericDockerOCIRuntime(FrontendEnvType):
         # Network access in grading container?
         out["network_grading"] = data.get("network_grading", False)
 
-        # SSH allowed ?
-        out["ssh_allowed"] = data.get("ssh_allowed", False)
-        if out["ssh_allowed"] == 'on':
-            out["ssh_allowed"] = True
-
         # Limits
         limits = {"time": 20, "memory": 1024, "disk": 1024}
         if "limits" in data:
@@ -59,3 +54,6 @@ class GenericDockerOCIRuntime(FrontendEnvType):
     def studio_env_template(self, templator, task, allow_html: bool):
         return templator.render("course_admin/edit_tabs/env_generic_docker_oci.html", env_params=task.get("environment_parameters", {}),
                                 content_is_html=allow_html, env_id=self.id)
+
+    def __init__(self, ssh_allowed=False):
+        self._ssh_allowed = ssh_allowed

--- a/inginious/frontend/environment_types/kata.py
+++ b/inginious/frontend/environment_types/kata.py
@@ -4,8 +4,8 @@ from inginious.frontend.environment_types.generic_docker_oci_runtime import Gene
 class KataEnvType(GenericDockerOCIRuntime):
     @property
     def id(self):
-        return "kata"
+        return "kata-ssh" if self._ssh_allowed else "kata"
 
     @property
     def name(self):
-        return _("Container running as root (Kata)")
+        return _("Container running as root (Kata) + SSH") if self._ssh_allowed else _("Container running as root (Kata)")

--- a/inginious/frontend/environment_types/nvidia.py
+++ b/inginious/frontend/environment_types/nvidia.py
@@ -4,8 +4,8 @@ from inginious.frontend.environment_types.generic_docker_oci_runtime import Gene
 class NvidiaEnvType(GenericDockerOCIRuntime):
     @property
     def id(self):
-        return "nvidia"
+        return "nvidia-ssh" if self._ssh_allowed else "nvidia"
 
     @property
     def name(self):
-        return _("Container with GPUs (NVIDIA)")
+        return _("Container with GPUs (NVIDIA) + SSH") if self._ssh_allowed else _("Container with GPUs (NVIDIA)")

--- a/inginious/frontend/templates/course_admin/edit_tabs/env_generic_docker_oci.html
+++ b/inginious/frontend/templates/course_admin/edit_tabs/env_generic_docker_oci.html
@@ -30,16 +30,6 @@
         </label></div>
     </div>
 </div>
-<div class="form-group row">
-    <label for="{{env_id}}-ssh-allowed" class="col-sm-4 control-label">{{ _("Allow ssh?") }}</label>
-
-    <div class="col-sm-8">
-        <div class="checkbox"><label>
-            <input type="checkbox" id="{{env_id}}-ssh-allowed" name="envparams[{{env_id}}][ssh_allowed]"
-                   {{'checked="checked"' if env_params.get('ssh_allowed',False) }} />&nbsp;
-        </label></div>
-    </div>
-</div>
 
 <div class="form-group row">
     <label for="{{env_id}}-run-cmd" class="col-sm-4 control-label">{{ _("Custom command to be run in container <small>(instead of running the run script)</small>") | safe}}</label>


### PR DESCRIPTION
This PR addresses issue #887 in which SSH jobs can wait indefinitely in the queue if no agent has SSH capability enabled because jobs are added based on the environment availability and removed based on what agents are capable.

It replaces the `ssh_allowed` environment parameter opt-in by multiple environment types. This ensures the job will always be treated as it won't be sent to the queue if the environment type has not been announced. It also removes any  SSH awareness from the queue and keep that concept in the specific environment code.

Another solution would have been to make the client code aware of SSH and prevent the job from getting in the queue, but that would have been heavier in terms of lines of code and would have introduced agent specificities into the common code.