### PR TITLE
[frontend/submission_manager] catch DocumentTooLarge exception

### DIFF
--- a/inginious/frontend/submission_manager.py
+++ b/inginious/frontend/submission_manager.py
@@ -76,16 +76,26 @@ class WebAppSubmissionManager:
         }
 
         # Save submission to database
-        submission = self._database.submissions.find_one_and_update(
-            {"_id": submission["_id"]},
-            {"$set": data, "$unset": unset_obj},
-            return_document=ReturnDocument.AFTER
-        )
+        try:
+            submission = self._database.submissions.find_one_and_update(
+                {"_id": submission["_id"]},
+                {"$set": data, "$unset": unset_obj},
+                return_document=ReturnDocument.AFTER
+            )
+
+            for username in submission["username"]:
+                self._user_manager.update_user_stats(username, task, submission, result[0], grade, state, newsub, task_dispenser)
+
+        # Check for size as it also takes the MongoDB command into consideration
+        except pymongo.errors.DocumentTooLarge:
+            data = {"status": "error", "text": _("Maximum submission size exceeded. Check feedback, stdout, stderr and state."), "grade": 0.0}
+            submission = self._database.submissions.find_one_and_update(
+                {"_id": submission["_id"]},
+                {"$set": data, "$unset": unset_obj},
+                return_document=ReturnDocument.AFTER
+            )
 
         self._plugin_manager.call_hook("submission_done", submission=submission, archive=archive, newsub=newsub)
-
-        for username in submission["username"]:
-            self._user_manager.update_user_stats(username, task, submission, result[0], grade, state, newsub, task_dispenser)
 
         if "outcome_service_url" in submission and "outcome_result_id" in submission and "outcome_consumer_key" in submission:
             for username in submission["username"]:


### PR DESCRIPTION
Fixes #697.

This is a first mitigation and in all case useful, as the limit is set on the total command sent to the MongoDB server, which cannot be computed before.

Do not update user stats in case of error.

Runfile to test : 
      
      #!/bin/bash
      dd if=/dev/random of=test.out bs=4M count=100
      cat test.out | tr -dc '[:alpha:]' | feedback-msg -a
      feedback-result success
