### PR TITLE
Update demo tasks repo URL to new organisation

### DIFF
--- a/doc/teacher_doc/course_tuto.rst
+++ b/doc/teacher_doc/course_tuto.rst
@@ -6,7 +6,7 @@ able to configure the course by themselves.
 
 .. note::
 
-    Demonstration tasks are made available for download on the `INGInious-demo-tasks repository <https://github.com/UCL-INGI/INGInious-demo-tasks>`_. They
+    Demonstration tasks are made available for download on the `INGInious-demo-tasks repository <https://github.com/INGInious/demo-tasks>`_. They
     can also be downloaded and installed automatically via the :ref:`inginious-install` script. You can also download courses examples on the marketplace page which allows to easily import courses files. The list of these open source courses is also available on the `INGInious-course repository <https://github.com/UCL-INGI/INGInious-courses>`_
 
 Using the webapp :

--- a/doc/teacher_doc/task_tuto.rst
+++ b/doc/teacher_doc/task_tuto.rst
@@ -5,7 +5,7 @@ In this document we will describe how to create a simple task, that checks that 
 
 .. note::
 
-    Demonstration tasks are made available for download on the `INGInious-demo-tasks repository <https://github.com/UCL-INGI/INGInious-demo-tasks>`_. They
+    Demonstration tasks are made available for download on the `INGInious-demo-tasks repository <https://github.com/INGInious/demo-tasks>`_. They
     can also be downloaded and installed automatically via the :ref:`inginious-install` script. You can also download courses examples on the marketplace page which allows to easily import courses files. The list of these open source courses is also available on the `INGInious-courses repository <https://github.com/UCL-INGI/INGInious-courses>`_
 	
 

--- a/inginious/frontend/installer.py
+++ b/inginious/frontend/installer.py
@@ -373,7 +373,7 @@ class Installer:
             self._display_question("Demonstration tasks can be downloaded to let you discover INGInious.")
             if self._ask_boolean("Would you like to download them ?", True):
                 try:
-                    self._retrieve_and_extract_tarball("https://api.github.com/repos/UCL-INGI/INGInious-demo-tasks/tarball", task_directory)
+                    self._retrieve_and_extract_tarball("https://api.github.com/repos/INGInious/demo-tasks/tarball", task_directory)
                     self._display_info("Successfully downloaded and copied demonstration tasks.")
                 except Exception as e:
                     self._display_error("An error occurred while copying the directory: %s" % str(e))


### PR DESCRIPTION
The demo tasks repository has been moved to the new INGInious organisation. See https://github.com/INGInious/demo-tasks