### PR TITLE
[task_dispensers] Task settings migration

### DIFF
--- a/inginious/frontend/task_dispensers/__init__.py
+++ b/inginious/frontend/task_dispensers/__init__.py
@@ -2,6 +2,7 @@ from abc import ABCMeta, abstractmethod
 
 
 class TaskDispenser(metaclass=ABCMeta):
+    legacy_fields = {}
 
     def __init__(self, task_list_func, dispenser_data, database, course_id):
         """
@@ -14,6 +15,7 @@ class TaskDispenser(metaclass=ABCMeta):
         self._task_list_func = task_list_func
         self._database = database
         self._course_id = course_id
+        self._dispenser_data = dispenser_data
 
     @abstractmethod
     def get_no_stored_submissions(self, taskid):
@@ -110,4 +112,12 @@ class TaskDispenser(metaclass=ABCMeta):
     @abstractmethod
     def get_ordered_tasks(self):
         """ Returns a serialized version of the tasks structure as an OrderedDict"""
+        pass
+
+    def has_legacy_tasks(self):
+        """ Checks if the task files contains dispenser settings """
+        return False
+
+    def import_legacy_tasks(self):
+        """ Imports the task dispenser settings from a task file dict """
         pass

--- a/inginious/frontend/task_dispensers/combinatory_test.py
+++ b/inginious/frontend/task_dispensers/combinatory_test.py
@@ -12,7 +12,8 @@ from inginious.frontend.accessible_time import AccessibleTime
 
 class CombinatoryTest(TableOfContents):
     config_items = [Weight, SubmissionStorage, EvaluationMode, Categories, SubmissionLimit, Accessibility]
-
+    legacy_fields = {"weight": Weight, "submission_limit": SubmissionLimit, "stored_submissions": SubmissionStorage,
+                     "evaluate": EvaluationMode, "accessible": Accessibility, "categories": Categories}
     @classmethod
     def get_id(cls):
         return "combinatory_test"

--- a/inginious/frontend/tasks.py
+++ b/inginious/frontend/tasks.py
@@ -215,3 +215,7 @@ class Task(object):
     def regenerate_input_random(self):
         """ Indicates if random inputs should be regenerated """
         return self._regenerate_input_random
+
+    def get_dispenser_settings(self, fields):
+        """ Fetch the legacy config fields now used by task dispensers """
+        return {field_class.get_id(): field_class.get_value({field_class.get_id(): self._data[field]}) for field, field_class in fields.items() if field in self._data}

--- a/inginious/frontend/templates/course_admin/task_dispensers/task_buttons.html
+++ b/inginious/frontend/templates/course_admin/task_dispensers/task_buttons.html
@@ -2,25 +2,30 @@
 {# more information about the licensing of this file. #}
 
 <div class="ml-auto btn-group btn-group-sm" role="group">
-    <button class="btn btn-primary" data-toggle="modal" data-target="#edit_{{taskid}}"
-            title="{{ _('Task parameters') }}" data-toggle="tooltip" data-placement="bottom">
+    <a class="task_settings btn btn-primary m-auto" data-toggle="modal" data-target="#edit_{{taskid}}"
+            title="{{ _('Task settings') }}">
         <i class="fa fa-cogs" aria-hidden="true"></i>
-    </button>
-    <a class="btn btn-success" href="{{get_homepath()}}/course/{{course.get_id()}}/{{taskid}}"
-            title="{{ _('View task') }}" data-toggle="tooltip" data-placement="bottom">
-        <i class="fa fa-eye"></i>
     </a>
-    <a class="rename_task btn btn-info" href="{{get_homepath()}}/admin/{{course.get_id()}}/edit/task/{{taskid}}"
+    <a class="view_task btn btn-success m-auto" href="{{get_homepath()}}/course/{{course.get_id()}}/{{taskid}}"
+            title="{{ _('View task') }}" data-toggle="tooltip" data-placement="bottom">
+        <i class="fa fa-eye" ></i>
+    </a>
+    <a class="edit_task btn btn-info m-auto" href="{{get_homepath()}}/admin/{{course.get_id()}}/edit/task/{{taskid}}"
             title="{{ _('Edit task') }}" data-toggle="tooltip" data-placement="bottom">
         <i class="fa fa-pencil"></i>
     </a>
-    <a class="rename_task btn btn-secondary" href="{{get_homepath()}}/admin/{{course.get_id()}}/submissions?tasks={{taskid}}"
+    <a class="rename_task btn btn-secondary m-auto" href="{{get_homepath()}}/admin/{{course.get_id()}}/submissions?tasks={{taskid}}"
             title="{{ _('View submissions') }}"  data-toggle="tooltip" data-placement="bottom">
         <i class="fa fa-file-code-o fa-fw"></i>
     </a>
 
-    <button class="delete_task btn btn-warning" data-toggle="modal" data-target="#delete_task_modal" onclick="dispenser_util_open_delete_modal(this)"
-            title="{{ _('Delete task') }}" data-toggle="tooltip" data-placement="bottom">
+    <button class="delete_task btn btn-warning m-auto" data-toggle="modal" data-target="#delete_task_modal" onclick="dispenser_util_open_delete_modal(this)"
+            title="{{ _('Delete task') }}">
         <i class="fa fa-trash"></i>
     </button>
 </div>
+
+<script type="text/javascript">
+    $(".task_settings").tooltip({"placement": "bottom"})
+    $(".delete_task").tooltip({"placement": "bottom"})
+</script>

--- a/inginious/frontend/templates/course_admin/task_list.html
+++ b/inginious/frontend/templates/course_admin/task_list.html
@@ -98,6 +98,20 @@
     </div>
 {% endif %}
 
+{% if task_dispenser.has_legacy_tasks() %}
+<div class="alert alert-warning pl-1" role="alert">
+    <form method="post">
+        <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+        <div class="row">
+            <div class="col-md-10 mt-1">
+                {{ _("This course currently includes legacy tasks with settings that have to be imported to the task dispenser settings to be effective.") }}
+            </div>
+            <div class="col-md-2"><button type="submit" name="migrate_tasks" class="btn btn-sm btn-block btn-danger"><i class="fa fa-rocket"></i> {{ _("Migrate tasks") }}</button></div>
+        </div>
+    </form>
+</div>
+{% endif %}
+
 <div id="dispenser_data">
     {{ task_dispenser.render_edit(template_helper, course, tasks) | safe }}
 </div>


### PR DESCRIPTION
This PR ends the long awaited process of task settings migration to task dispensers, first step to ease task sharing among courses.

As discussed with @nrybowski, the online but manual way was preferred to trigger the task file update. Therefore, a migration option is added in top of the task list page in case the current task dispenser detects legacy settings in the task files. When the upgrade is asked, the current task dispenser will import the task settings into its own data structure and then the fields imported will be removed from task file descriptors.

This is implemented by adding two function definitions to task dispensers : `has_legacy_tasks` and `import_legacy_tasks` as well as a `legacy_fields` attribute to workaround the fact task dispensers have no access to the descriptors to modify the files themselves. A default newly defined task dispenser will inherit these definitions but they will have no effect on the tasks. They are purposely not defined as abstract methods then.