### PR TITLE
[frontend] Adding the use of Argon2id for password hashing

### DIFF
--- a/inginious/frontend/installer.py
+++ b/inginious/frontend/installer.py
@@ -566,7 +566,7 @@ class Installer:
         database.users.insert_one({"username": username,
                                    "realname": realname,
                                    "email": email,
-                                   "password": UserManager.hash_password_sha512(password),
+                                   "password": "argon2id-" + UserManager.hash_password_argon2id(password),
                                    "bindings": {},
                                    "language": "en"})
 

--- a/inginious/frontend/installer.py
+++ b/inginious/frontend/installer.py
@@ -566,7 +566,7 @@ class Installer:
         database.users.insert_one({"username": username,
                                    "realname": realname,
                                    "email": email,
-                                   "password": UserManager.hash_password(password),
+                                   "password": UserManager.hash_password_sha512(password),
                                    "bindings": {},
                                    "language": "en"})
 

--- a/inginious/frontend/installer.py
+++ b/inginious/frontend/installer.py
@@ -566,7 +566,7 @@ class Installer:
         database.users.insert_one({"username": username,
                                    "realname": realname,
                                    "email": email,
-                                   "password": "argon2id-" + UserManager.hash_password_argon2id(password),
+                                   "password": UserManager.hash_password(password),
                                    "bindings": {},
                                    "language": "en"})
 

--- a/inginious/frontend/pages/course_admin/danger_zone.py
+++ b/inginious/frontend/pages/course_admin/danger_zone.py
@@ -217,7 +217,7 @@ class CourseDangerZonePage(INGIniousAdminPage):
 
     def page(self, course, msg="", error=False):
         """ Get all data and display the page """
-        thehash = UserManager.hash_password(str(random.getrandbits(256)))
+        thehash = UserManager.hash_password_sha512(str(random.getrandbits(256)))
         self.user_manager.set_session_token(thehash)
 
         backups = self.get_backup_list(course)

--- a/inginious/frontend/pages/preferences/profile.py
+++ b/inginious/frontend/pages/preferences/profile.py
@@ -54,8 +54,8 @@ class ProfilePage(INGIniousAuthPage):
             msg = _("Passwords don't match !")
             return result, msg, error
         elif self.app.allow_registration and len(data["passwd"]) >= 6:
-            oldpasswd_hash = UserManager.hash_password(data["oldpasswd"])
-            passwd_hash = UserManager.hash_password(data["passwd"])
+            oldpasswd_hash = UserManager.hash_password_sha512(data["oldpasswd"])
+            passwd_hash = UserManager.hash_password_sha512(data["passwd"])
 
             match = {"username": self.user_manager.session_username()}
             if "password" in userdata:

--- a/inginious/frontend/pages/preferences/profile.py
+++ b/inginious/frontend/pages/preferences/profile.py
@@ -59,15 +59,18 @@ class ProfilePage(INGIniousAuthPage):
 
             if "password" in userdata:
                 user = self.user_manager.auth_user(self.user_manager.session_username(), data["oldpasswd"], False)
-                if user is None:
-                    error = True
-                    msg = _("Incorrect old password.")
-                    return result, msg, error
-                else:
-                    passwd_hash = UserManager.hash_password(data["passwd"])
-                    result = self.database.users.find_one_and_update({"username": self.user_manager.session_username()},
-                                                                     {"$set": {"password": passwd_hash}},
-                                                                     return_document=ReturnDocument.AFTER)
+            else:
+                user = self.database.users.find_one({"username": userdata["username"]})
+
+            if user is None:
+                error = True
+                msg = _("Incorrect old password.")
+                return result, msg, error
+            else:
+                passwd_hash = UserManager.hash_password(data["passwd"])
+                result = self.database.users.find_one_and_update({"username": self.user_manager.session_username()},
+                                                                 {"$set": {"password": passwd_hash}},
+                                                                 return_document=ReturnDocument.AFTER)
 
         # Check if updating language
         if data["language"] != userdata["language"]:

--- a/inginious/frontend/pages/preferences/profile.py
+++ b/inginious/frontend/pages/preferences/profile.py
@@ -63,7 +63,7 @@ class ProfilePage(INGIniousAuthPage):
                 oldpasswd_hash_sha512 = UserManager.hash_password_sha512(data["oldpasswd"])
                 try:
                     if oldpasswd_hash_sha512 == user["password"] or ph.verify(user["password"][9:], data["oldpasswd"]):
-                        passwd_hash = "argon2id-" + UserManager.hash_password_argon2id(data["passwd"])
+                        passwd_hash = UserManager.hash_password(data["passwd"])
 
                 except VerifyMismatchError:
                     error = True

--- a/inginious/frontend/pages/register.py
+++ b/inginious/frontend/pages/register.py
@@ -91,7 +91,7 @@ class RegistrationPage(INGIniousPage):
                 else:
                     msg = _("This email address is already in use !")
             else:
-                passwd_hash = "argon2id-" + UserManager.hash_password_argon2id(data["passwd"])
+                passwd_hash = UserManager.hash_password(data["passwd"])
                 activate_hash = UserManager.hash_password_sha512(str(random.getrandbits(256)))
                 self.database.users.insert_one({"username": data["username"],
                                                 "realname": data["realname"],
@@ -180,7 +180,7 @@ Someone (probably you) asked to reset your INGInious password. If this was you, 
             msg = _("Passwords don't match !")
 
         if not error:
-            passwd_hash = "argon2id-" + UserManager.hash_password_argon2id(data["passwd"])
+            passwd_hash = UserManager.hash_password(data["passwd"])
             user = self.database.users.find_one_and_update({"reset": data["reset"]},
                                                            {"$set": {"password": passwd_hash},
                                                             "$unset": {"reset": True, "activate": True}})

--- a/inginious/frontend/pages/register.py
+++ b/inginious/frontend/pages/register.py
@@ -91,8 +91,8 @@ class RegistrationPage(INGIniousPage):
                 else:
                     msg = _("This email address is already in use !")
             else:
-                passwd_hash = UserManager.hash_password(data["passwd"])
-                activate_hash = UserManager.hash_password(str(random.getrandbits(256)))
+                passwd_hash = UserManager.hash_password_sha512(data["passwd"])
+                activate_hash = UserManager.hash_password_sha512(str(random.getrandbits(256)))
                 self.database.users.insert_one({"username": data["username"],
                                                 "realname": data["realname"],
                                                 "email": email,
@@ -138,7 +138,7 @@ To activate your account, please click on the following link :
             msg = _("Invalid email format.")
 
         if not error:
-            reset_hash = UserManager.hash_password(str(random.getrandbits(256)))
+            reset_hash = UserManager.hash_password_sha512(str(random.getrandbits(256)))
             user = self.database.users.find_one_and_update({"email": data["recovery_email"]},
                                                            {"$set": {"reset": reset_hash}})
             if user is None:
@@ -180,7 +180,7 @@ Someone (probably you) asked to reset your INGInious password. If this was you, 
             msg = _("Passwords don't match !")
 
         if not error:
-            passwd_hash = UserManager.hash_password(data["passwd"])
+            passwd_hash = UserManager.hash_password_sha512(data["passwd"])
             user = self.database.users.find_one_and_update({"reset": data["reset"]},
                                                            {"$set": {"password": passwd_hash},
                                                             "$unset": {"reset": True, "activate": True}})

--- a/inginious/frontend/pages/register.py
+++ b/inginious/frontend/pages/register.py
@@ -91,7 +91,7 @@ class RegistrationPage(INGIniousPage):
                 else:
                     msg = _("This email address is already in use !")
             else:
-                passwd_hash = UserManager.hash_password_sha512(data["passwd"])
+                passwd_hash = "argon2id-" + UserManager.hash_password_argon2id(data["passwd"])
                 activate_hash = UserManager.hash_password_sha512(str(random.getrandbits(256)))
                 self.database.users.insert_one({"username": data["username"],
                                                 "realname": data["realname"],
@@ -180,7 +180,7 @@ Someone (probably you) asked to reset your INGInious password. If this was you, 
             msg = _("Passwords don't match !")
 
         if not error:
-            passwd_hash = UserManager.hash_password_sha512(data["passwd"])
+            passwd_hash = "argon2id-" + UserManager.hash_password_argon2id(data["passwd"])
             user = self.database.users.find_one_and_update({"reset": data["reset"]},
                                                            {"$set": {"password": passwd_hash},
                                                             "$unset": {"reset": True, "activate": True}})

--- a/inginious/frontend/user_manager.py
+++ b/inginious/frontend/user_manager.py
@@ -21,6 +21,7 @@ from pymongo import ReturnDocument
 from binascii import hexlify
 import os
 import re
+from argon2 import PasswordHasher
 
 
 class AuthInvalidInputException(Exception):
@@ -1040,3 +1041,12 @@ class UserManager:
         :return a hash of str input
         """
         return hashlib.sha512(content.encode("utf-8")).hexdigest()
+
+    @classmethod
+    def hash_password_argon2id(cls, content):
+        """
+        :param content: a str input
+        :return a hash of str input
+        """
+        ph = PasswordHasher()
+        return ph.hash(content)

--- a/inginious/frontend/user_manager.py
+++ b/inginious/frontend/user_manager.py
@@ -22,6 +22,7 @@ from binascii import hexlify
 import os
 import re
 from argon2 import PasswordHasher
+from argon2.exceptions import VerifyMismatchError
 
 
 class AuthInvalidInputException(Exception):
@@ -305,7 +306,7 @@ class UserManager:
             elif self.hash_password_sha512(password) == user["password"] or ph.verify(user["password"][9:], password):
                 return user and self.connect_user(username, user["realname"], user["email"],user["language"],
                                                   user.get("tos_accepted", False))
-        except:  # ph.verify() raises Error if hash does not correspond or has incorrect structure
+        except VerifyMismatchError: 
             return None
 
 

--- a/inginious/frontend/user_manager.py
+++ b/inginious/frontend/user_manager.py
@@ -299,17 +299,16 @@ class UserManager:
         user = self._database.users.find_one(
             {"username": username, "activate": {"$exists": False}})
 
-        def connect_user(username, user, do_connect):
-            return (user and self.connect_user(username, user["realname"], user["email"], user["language"],
-                                               user.get("tos_accepted", False)) if do_connect else user)
-
         if user is None:
             return None
 
-        method, db_hash = user["password"].split("-") if "-" in user["password"] else ("sha512", user["password"])
+        method, db_hash = user["password"].split("-", 1) if "-" in user["password"] else ("sha512", user["password"])
 
         if self.verify_hash(db_hash, password, method):
-            return connect_user(username, user, do_connect)
+            if do_connect:
+                self.connect_user(username, user["realname"], user["email"], user["language"],
+                                  user.get("tos_accepted", False))
+            return user
 
     def verify_hash(cls, db_hash, password, method="sha512"):
         """

--- a/inginious/frontend/user_manager.py
+++ b/inginious/frontend/user_manager.py
@@ -1084,7 +1084,7 @@ class UserManager:
         :return a hash of str input
         """
         ph = PasswordHasher()
-        return "argon2id-" + ph.hash(content)
+        return ph.hash(content)
 
     @classmethod
     def hash_password(cls, content):
@@ -1097,4 +1097,4 @@ class UserManager:
         methods = {"argon2id": cls.hash_password_argon2id, "sha512": cls.hash_password_sha512}
         latest_method = "argon2id"
 
-        return methods[latest_method](content)
+        return latest_method + "-" + methods[latest_method](content)

--- a/inginious/frontend/user_manager.py
+++ b/inginious/frontend/user_manager.py
@@ -293,7 +293,7 @@ class UserManager:
         :param password: User password
         :return: Returns a dict representing the user
         """
-        password_hash = self.hash_password(password)
+        password_hash = self.hash_password_sha512(password)
 
         user = self._database.users.find_one(
             {"username": username, "password": password_hash, "activate": {"$exists": False}})
@@ -539,7 +539,7 @@ class UserManager:
         self._database.users.insert_one({"username": values["username"],
                                          "realname": values["realname"],
                                          "email": values["email"],
-                                         "password": self.hash_password(values["password"]),
+                                         "password": self.hash_password_sha512(values["password"]),
                                          "bindings": {},
                                          "language": "en"})
         return None
@@ -1034,7 +1034,7 @@ class UserManager:
         return hexlify(os.urandom(40)).decode('utf-8')
 
     @classmethod
-    def hash_password(cls, content):
+    def hash_password_sha512(cls, content):
         """
         :param content: a str input
         :return a hash of str input

--- a/inginious/frontend/user_manager.py
+++ b/inginious/frontend/user_manager.py
@@ -1056,4 +1056,17 @@ class UserManager:
         :return a hash of str input
         """
         ph = PasswordHasher()
-        return ph.hash(content)
+        return "argon2id-" + ph.hash(content)
+
+    @classmethod
+    def hash_password(cls, content):
+        """
+        Encapsulates the other password hashing functions
+        :param content: a str input
+        :return a hash of str input
+        """
+
+        methods = {"argon2id": cls.hash_password_argon2id, "sha512": cls.hash_password_sha512}
+        latest_method = "argon2id"
+
+        return methods[latest_method](content)

--- a/inginious/frontend/user_manager.py
+++ b/inginious/frontend/user_manager.py
@@ -294,10 +294,11 @@ class UserManager:
         :param password: User password
         :return: Returns a dict representing the user
         """
-        password_hash = self.hash_password_sha512(password)
+        password_hash_sha512 = self.hash_password_sha512(password)
+        password_hash_argon2id = "argon2id-" + self.hash_password_argon2id(password)
 
         user = self._database.users.find_one(
-            {"username": username, "password": password_hash, "activate": {"$exists": False}})
+            {"username": username, "password": {"$in": [password_hash_sha512, password_hash_argon2id]}, "activate": {"$exists": False}})
 
         return user if user is not None and self.connect_user(username, user["realname"], user["email"],
                                                               user["language"],

--- a/inginious/frontend/user_manager.py
+++ b/inginious/frontend/user_manager.py
@@ -540,7 +540,7 @@ class UserManager:
         self._database.users.insert_one({"username": values["username"],
                                          "realname": values["realname"],
                                          "email": values["email"],
-                                         "password": self.hash_password_sha512(values["password"]),
+                                         "password": "argon2id-"+self.hash_password_argon2id(values["password"]),
                                          "bindings": {},
                                          "language": "en"})
         return None

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ install_requires = [
     "Werkzeug==3.0.1",
     "WsgiDAV==4.3.0",
     "zipstream==1.1.4"
+    "argon2-cffi == 23.1.0"
 ]
 
 test_requires = [


### PR DESCRIPTION
Related to issue #358 

This pull request contains changes regarding multiple elements : 
- Adding a new hashing function hash_password_argon2id and renaming the old one to hash_password_sha512.
- Supporting user authentication regardless of the algorithm hashing their password in the database. 
- Using the argon2 hash for new users (via self registering, administrator registering or during the installation process).
- Using the argon2 hash when a users resets it's password or changes it

Password hashes with argon2id are now stored in the database using a prepend "argon2id-" to allow future changes.