### PR TITLE
[frontend] Adding empty string check when gettexting

### DIFF
--- a/inginious/common/tasks_problems.py
+++ b/inginious/common/tasks_problems.py
@@ -133,8 +133,10 @@ class Problem(object, metaclass=ABCMeta):
     def get_translation_obj(self, language=None):
         return self._translations.get(language, gettext.NullTranslations())
 
-    def gettext(self, language, *args, **kwargs):
-        return self.get_translation_obj(language).gettext(*args, **kwargs)
+    def gettext(self, language, text):
+        if text == "":
+            return text
+        return self.get_translation_obj(language).gettext(text)
 
 
 class CodeProblem(Problem):

--- a/inginious/frontend/courses.py
+++ b/inginious/frontend/courses.py
@@ -113,8 +113,10 @@ class Course(object):
     def get_translation_obj(self, language):
         return self._translations.get(language, gettext.NullTranslations())
 
-    def gettext(self, language, *args, **kwargs):
-        return self.get_translation_obj(language).gettext(*args, **kwargs)
+    def gettext(self, language, text):
+        if text == "":
+            return text
+        return self.get_translation_obj(language).gettext(text)
 
     def get_id(self):
         """ Return the _id of this course """

--- a/inginious/frontend/l10n_manager.py
+++ b/inginious/frontend/l10n_manager.py
@@ -17,5 +17,7 @@ class L10nManager:
             lang = self._session.get("language", "") if flask.has_app_context() else ""
         return self.translations.get(lang, gettext.NullTranslations())
 
-    def gettext(self, *args, **kwargs):
-        return self.get_translation_obj().gettext(*args, **kwargs)
+    def gettext(self, text):
+        if text == "":
+            return text
+        return self.get_translation_obj().gettext(text)

--- a/inginious/frontend/tasks.py
+++ b/inginious/frontend/tasks.py
@@ -115,8 +115,10 @@ class Task(object):
     def get_translation_obj(self, language):
         return self._translations.get(language, gettext.NullTranslations())
 
-    def gettext(self, language, *args, **kwargs):
-        return self.get_translation_obj(language).gettext(*args, **kwargs)
+    def gettext(self, language, text):
+        if text == "":
+            return text
+        return self.get_translation_obj(language).gettext(text)
 
     def input_is_consistent(self, task_input, default_allowed_extension, default_max_size):
         """ Check if an input for a task is consistent. Return true if this is case, false else """


### PR DESCRIPTION
PR related to #899 

Contains : 
- Adding checks on the different gettext calls to avoid gettexting empty strings
- Remove *args and **kwargs parameters for gettext as it uses only one : the string to translate