### PR TITLE
V0.8 dependecies fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import os
 from setuptools import setup, find_packages
 
 install_requires = [
-    "docker == 7.1.0", # docker 6.1.0 ? -> docker-py = ancienne version de docker
+    "docker == 7.1.0", 
     "docutils == 0.20.1",
     "pymongo == 4.10.1",
     "PyYAML == 6.0.2",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 install_requires = [
     "docker == 7.1.0", 
     "docutils == 0.20.1",
-    "setuptools == 74.1.3",
+    "setuptools == 75.8.0",
     "pymongo == 4.10.1",
     "PyYAML == 6.0.2",
     "Jinja2 == 3.1.4",
@@ -30,7 +30,6 @@ install_requires = [
     "Flask == 2.3.3",
     "Flask-Mail == 0.10.0",
     "importlib_metadata == 8.5.0",
-    'dataclasses == 0.8; python_version < "3.7.0"',
     "pytidylib == 0.3.2",
     "sphinx-autodoc-typehints == 2.0.1",
 ]

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ from setuptools import setup, find_packages
 install_requires = [
     "docker == 7.1.0", 
     "docutils == 0.20.1",
+    "setuptools == 74.1.3",
     "pymongo == 4.10.1",
     "PyYAML == 6.0.2",
     "Jinja2 == 3.1.4",

--- a/setup.py
+++ b/setup.py
@@ -9,30 +9,29 @@ import os
 from setuptools import setup, find_packages
 
 install_requires = [
-    "docker>=3.0",
-    "requests < 2.29.0",  # TODO: remove when https://github.com/docker/docker-py/issues/3113 is closed.
-    "docutils>=0.14",
-    "pymongo>=3.2.2",
-    "PyYAML>=3.11",
-    "Jinja2 >= 2.10",
-    "lti>=0.9.0",
-    "oauth2>=1.9.0.post1",
-    "httplib2>=0.9",
-    "watchdog >= 0.8.3",
-    "msgpack >= 1.0.0",
-    "pyzmq >= 15.3.0",
-    "natsort >= 5.0.1",
-    "psutil >= 4.4.2",
-    "zipstream >= 1.1.4",
-    "WsgiDAV >= 3.0.0",
-    "Werkzeug >= 1.0.0",
-    "itsdangerous >= 1.1.0",
-    "Flask >= 2.0.0",
-    "Flask-Mail >= 0.9.1",
-    "importlib_metadata >= 3.7.0",
-    'dataclasses >= 0.8; python_version < "3.7.0"',
-    "pytidylib>=0.2.4",
-    "sphinx-autodoc-typehints>=1.12.0",
+    "docker == 7.1.0", # docker 6.1.0 ? -> docker-py = ancienne version de docker
+    "docutils == 0.20.1",
+    "pymongo == 4.10.1",
+    "PyYAML == 6.0.2",
+    "Jinja2 == 3.1.4",
+    "lti == 0.9.5",
+    "oauth2 == 1.9.0.post1",
+    "httplib2 == 0.22.0",
+    "watchdog == 4.0.2",
+    "msgpack == 1.1.0",
+    "pyzmq == 26.2.0",
+    "natsort == 8.4.0",
+    "psutil == 6.1.0",
+    "zipstream == 1.1.4",
+    "WsgiDAV == 4.3.3",
+    "Werkzeug == 2.3.7",
+    "itsdangerous == 2.2.0",
+    "Flask == 2.3.3",
+    "Flask-Mail == 0.10.0",
+    "importlib_metadata == 8.5.0",
+    'dataclasses == 0.8; python_version < "3.7.0"',
+    "pytidylib == 0.3.2",
+    "sphinx-autodoc-typehints == 2.0.1",
 ]
 
 test_requires = [
@@ -44,10 +43,10 @@ test_requires = [
 ]
 
 doc_requires = [
-    "sphinx==4.5.0",
-    "sphinx_rtd_theme==1.0.0",
-    "sphinx-tabs==3.3.1",
-    "ipython==8.2.0"
+    "sphinx == 7.1.2",
+    "sphinx_rtd_theme == 1.0.0",
+    "sphinx-tabs == 3.3.1",
+    "ipython == 8.2.0"
 ]
 
 if sys.platform == 'win32':


### PR DESCRIPTION
This PR has as goal to set the package dependencies to exact versions as well as impose the 2.3.7 version of Werkzeug to avoid the reoccurring dependency problem related (see #1013).