### PR TITLE
fix typo regarding refactoring from course_factory to taskset_factory

### DIFF
--- a/inginious/frontend/pages/api/courses.py
+++ b/inginious/frontend/pages/api/courses.py
@@ -45,10 +45,10 @@ class APICourses(APIAuthenticatedPage):
         output = []
 
         if courseid is None:
-            courses = self.taskset_factory.get_all_courses()
+            courses = self.course_factory.get_all_courses()
         else:
             try:
-                courses = {courseid: self.taskset_factory.get_course(courseid)}
+                courses = {courseid: self.course_factory.get_course(courseid)}
             except:
                 raise APINotFound("Course not found")
 

--- a/inginious/frontend/pages/api/submissions.py
+++ b/inginious/frontend/pages/api/submissions.py
@@ -12,13 +12,13 @@ import flask
 from inginious.frontend.pages.api._api_page import APIAuthenticatedPage, APINotFound, APIForbidden, APIInvalidArguments, APIError
 
 
-def _get_submissions(taskset_factory, submission_manager, user_manager, translations, courseid, taskid, with_input, submissionid=None):
+def _get_submissions(course_factory, submission_manager, user_manager, translations, courseid, taskid, with_input, submissionid=None):
     """
         Helper for the GET methods of the two following classes
     """
 
     try:
-        course = taskset_factory.get_course(courseid)
+        course = course_factory.get_course(courseid)
     except:
         raise APINotFound("Course not found")
 
@@ -168,7 +168,7 @@ class APISubmissions(APIAuthenticatedPage):
         """
 
         try:
-            course = self.taskset_factory.get_course(courseid)
+            course = self.course_factory.get_course(courseid)
         except:
             raise APINotFound("Course not found")
 

--- a/inginious/frontend/pages/api/tasks.py
+++ b/inginious/frontend/pages/api/tasks.py
@@ -61,7 +61,7 @@ class APITasks(APIAuthenticatedPage):
         """
 
         try:
-            course = self.taskset_factory.get_course(courseid)
+            course = self.course_factory.get_course(courseid)
         except:
             raise APINotFound("Course not found")
 

--- a/inginious/frontend/pages/group.py
+++ b/inginious/frontend/pages/group.py
@@ -22,7 +22,7 @@ class GroupPage(INGIniousAuthPage):
     def GET_AUTH(self, courseid):  # pylint: disable=arguments-differ
         """ GET request """
 
-        course = self.taskset_factory.get_course(courseid)
+        course = self.course_factory.get_course(courseid)
         username = self.user_manager.session_username()
 
         error = False

--- a/inginious/frontend/pages/utils.py
+++ b/inginious/frontend/pages/utils.py
@@ -25,6 +25,7 @@ from inginious.frontend.user_manager import UserManager
 from inginious.frontend.parsable_text import ParsableText
 from pymongo.database import Database
 
+from inginious.frontend.course_factory import CourseFactory
 from inginious.frontend.taskset_factory import TasksetFactory
 from inginious.frontend.task_factory import TaskFactory
 from inginious.frontend.lti_outcome_manager import LTIOutcomeManager
@@ -76,7 +77,7 @@ class INGIniousPage(MethodView):
         return self.app.taskset_factory
 
     @property
-    def course_factory(self) -> TaskFactory:
+    def course_factory(self) -> CourseFactory:
         """ Returns the task factory singleton """
         return self.app.course_factory
 

--- a/inginious/frontend/plugins/contests/__init__.py
+++ b/inginious/frontend/plugins/contests/__init__.py
@@ -95,7 +95,7 @@ class ContestScoreboard(INGIniousAuthPage):
     """ Displays the scoreboard of the contest """
 
     def GET_AUTH(self, courseid):  # pylint: disable=arguments-differ
-        course = self.taskset_factory.get_course(courseid)
+        course = self.course_factory.get_course(courseid)
         task_dispenser = course.get_task_dispenser()
         if not task_dispenser.get_id() == Contest.get_id():
             raise NotFound()
@@ -191,9 +191,9 @@ class ContestAdmin(INGIniousAdminPage):
 
     def save_contest_data(self, course, contest_data):
         """ Saves updated contest data for the course """
-        course_content = self.taskset_factory.get_course_descriptor_content(course.get_id())
+        course_content = self.course_factory.get_course_descriptor_content(course.get_id())
         course_content["dispenser_data"]["contest_settings"] = contest_data
-        self.taskset_factory.update_course_descriptor_content(course.get_id(), course_content)
+        self.course_factory.update_course_descriptor_content(course.get_id(), course_content)
 
     def GET_AUTH(self, courseid):  # pylint: disable=arguments-differ
         """ GET request: simply display the form """

--- a/inginious/frontend/plugins/simple_grader/__init__.py
+++ b/inginious/frontend/plugins/simple_grader/__init__.py
@@ -14,7 +14,7 @@ from inginious.client.client_sync import ClientSync
 from inginious.frontend.pages.utils import INGIniousPage
 
 
-def init(plugin_manager, taskset_factory, client, config):
+def init(plugin_manager, course_factory, client, config):
     """
         Init the external grader plugin. This simple grader allows only anonymous requests, and submissions are not stored in database.
 
@@ -32,7 +32,7 @@ def init(plugin_manager, taskset_factory, client, config):
         Different types of request are available : see documentation
     """
     courseid = config.get('courseid', 'external')
-    course = taskset_factory.get_course(courseid)
+    course = course_factory.get_course(courseid)
     page_pattern = config.get('page_pattern', '/external')
     return_fields = re.compile(config.get('return_fields', '^(result|text|problems)$'))
 

--- a/inginious/frontend/plugins/upcoming_tasks/__init__.py
+++ b/inginious/frontend/plugins/upcoming_tasks/__init__.py
@@ -53,7 +53,7 @@ class UpComingTasksBoard(INGIniousAuthPage):
     def page(self, time_planner):
         """ General main method called for GET and POST """
         username = self.user_manager.session_username()
-        all_courses = self.taskset_factory.get_all_courses()
+        all_courses = self.course_factory.get_all_courses()
         time_planner = self.time_planner_conversion(time_planner)
 
         # Get the courses id


### PR DESCRIPTION
During a refactoring in order to get rid of the course_factory, some "course_factory" were replaced by "taskset_factory" and should not have been.

This PR simply restores the right variables.