### PR TITLE
Fix - removed indentation in tutorial

### DIFF
--- a/doc/teacher_doc/task_tuto.rst
+++ b/doc/teacher_doc/task_tuto.rst
@@ -72,10 +72,9 @@ in the webapp in the *Task files* tab of the *Edit task* page.
 #. Create a template file ``template.py``, where we will put the code of the student.
    ::
 
-       def func():
-           @    @question1@@
-
-           func()
+	def func():
+        	@    @question1@@
+	func()
 
    The syntax is very simple: put a first ``@`` on the line where you want to put the code of the student.
    Then indent the line and write a second ``@``. Now write the problem id of the problem you want to take the input


### PR DESCRIPTION
This is a PR to solve an issue related to the doc.

Looking at the tutorial of how to write an hello world exercise, it stated an example of the code to put in a template file to run the student code.

The problem is that the student code is inside the function and the funtion was called at the end of the function instead of being called after the function definition. This would result in not being able to run the student code but even by running the function it will be an infinite loop. 

To solve this, I had to remove one indentation level as Python works with identation at the right level to call a function. By testing, the code was indeed showing nothing before the change and displayed "hello world" after changes.