### PR TITLE
fix(setup): hardcoded stable version of setuptools_scm

### DIFF
--- a/COPYRIGHTS
+++ b/COPYRIGHTS
@@ -1,6 +1,6 @@
   The vast majority of the files are
 
-         Copyright (c) 2014-2024 Anthony Gégo, Guillaume Derval
+         Copyright (c) 2014-2025 Anthony Gégo, Guillaume Derval
                          and Pierre Reinbold
 
   Some of the files contain contributions from other persons, institutions or

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     use_scm_version=True,
     description="An intelligent grader that allows secured and automated testing of code made by students.",
     packages=find_packages(),
-    setup_requires=['setuptools_scm'],
+    setup_requires=['setuptools_scm==8.1.0'],
     install_requires=install_requires,
     tests_require=test_requires,
     extras_require={


### PR DESCRIPTION
This contribution aims to solve a problem at the installation of INGInious due to an update in a library.

### What is the issue ?

When installing INGInious by using the `docker compose up --builder` command, an error occurs at the end of the installation :

![Screenshot from 2025-02-25 18-13-20](https://github.com/user-attachments/assets/6c3c9a6e-54ce-4471-be38-b24119510740)


### How to reproduce it ?

1) Clone the repository

2) Launch the command : `sudo docker compose up --builder`


### What is the problem ?

It appears that the problem is because the package `setuptools_scm` received a new version (8.2.0) that breaks the installation of INGInious.


### How to solve the problem ?

One solution is to fix the version to the previous one where the installation was working (8.1.0). By setting it in `setup.py`, the installation is now working.