### PR TITLE
[cleanup 8] FSProvider singleton

### DIFF
--- a/doc/dev_doc/extensions_doc/plugins.rst
+++ b/doc/dev_doc/extensions_doc/plugins.rst
@@ -25,7 +25,7 @@ The following code adds a new page displaying ``This is a simple demo plugin`` o
             return "This is a simple demo plugin"
 
 
-    def init(plugin_manager, fs_provider, client, plugin_config):
+    def init(plugin_manager, client, plugin_config):
         """ Init the plugin """
         plugin_manager.add_page("/plugindemo", DemoPage.as_view('demopage'))
 
@@ -35,9 +35,6 @@ This method takes four arguments:
 
 - ``plugin_manager`` which is the plugin manager singleton object. The detailed API is available at
   :ref:`inginious.frontend.plugins.plugin_manager`.
-
-- ``fs_provider`` which is the FileSystemProvider singleton object, giving you abstraction to the tasks folder. The detailed
-  API is available at :ref:`inginious.common.filesystems.FileSystemProvider`.
 
 - ``client`` which is the INGInious client singleton object, giving you access to the backend features, as launching
   a new job. The detailed API is available at :ref:`inginious.client.client`.
@@ -78,7 +75,7 @@ would therefore need to add a hook method. This can be done using the ``add_hook
     def submission_done(submission, archive, newsub):
         logging.getLogger("inginious.frontend.plugins.demo").info("Submission " + str(submission['_id']) + " done.")
 
-    def init(plugin_manager, fs_provider, client, plugin_config):
+    def init(plugin_manager, client, plugin_config):
         """ Init the plugin """
         plugin_manager.add_hook("submission_done", submission_done)
 

--- a/inginious/agent/__init__.py
+++ b/inginious/agent/__init__.py
@@ -15,6 +15,8 @@ import zmq
 from inginious.common.messages import AgentHello, BackendJobId, SPResult, AgentJobDone, BackendNewJob, BackendKillJob, \
     AgentJobStarted, AgentJobSSHDebug, Ping, Pong, ZMQUtils
 
+from inginious.common.filesystems import get_fs_provider
+
 """
 Various utils to implements new kind of agents easily.
 """
@@ -48,17 +50,16 @@ class Agent(object, metaclass=ABCMeta):
     An INGInious agent, that grades specific kinds of jobs, and interacts with a Backend.
     """
 
-    def __init__(self, context, backend_addr, friendly_name, concurrency, filesystem):
+    def __init__(self, context, backend_addr, friendly_name, concurrency):
         """
         :param context: a ZMQ context to which the agent will be linked
         :param backend_addr: address of the backend to which the agent should connect. The format is the same as ZMQ
         :param concurrency: number of simultaneous jobs that can be run by this agent
-        :param filesystem: filesystem for the tasks
         """
         # These fields can be read/modified/overridden in subclasses
         self._logger = logging.getLogger("inginious.agent")
         self._loop = asyncio.get_event_loop()
-        self._fs = filesystem
+        self._fs = get_fs_provider()
 
         # These fields should not be read/modified/overridden in subclasses
         self.__concurrency = concurrency

--- a/inginious/agent/docker_agent/__init__.py
+++ b/inginious/agent/docker_agent/__init__.py
@@ -23,7 +23,6 @@ from inginious.agent.docker_agent._docker_runtime import DockerRuntime
 from inginious.agent.docker_agent._timeout_watcher import TimeoutWatcher
 from inginious.common.asyncio_utils import AsyncIteratorWrapper, AsyncProxy
 from inginious.common.base import id_checker, id_checker_tests
-from inginious.common.filesystems import FileSystemProvider
 from inginious.common.messages import BackendNewJob, BackendKillJob
 
 
@@ -64,14 +63,13 @@ class DockerRunningStudentContainer:
 
 
 class DockerAgent(Agent):
-    def __init__(self, context, backend_addr, friendly_name, concurrency, tasks_fs: FileSystemProvider,
+    def __init__(self, context, backend_addr, friendly_name, concurrency,
                  address_host=None, external_ports=None, tmp_dir="./agent_tmp", runtimes=None, ssh_allowed=False):
         """
         :param context: ZeroMQ context for this process
         :param backend_addr: address of the backend (for example, "tcp://127.0.0.1:2222")
         :param friendly_name: a string containing a friendly name to identify agent
         :param concurrency: number of simultaneous jobs that can be run by this agent
-        :param tasks_fs: FileSystemProvider for the course / tasks
         :param address_host: hostname/ip/... to which external client should connect to access to the docker
         :param external_ports: iterable containing ports to which the docker instance can bind internal ports
         :param tmp_dir: temp dir that is used by the agent to start new containers
@@ -79,7 +77,7 @@ class DockerAgent(Agent):
         :param runtime: runtime used by docker (the defaults are "runc" with docker or "kata-runtime" with kata)
         :param ssh_allowed: boolean to make this agent accept tasks with ssh or not
         """
-        super(DockerAgent, self).__init__(context, backend_addr, friendly_name, concurrency, tasks_fs)
+        super(DockerAgent, self).__init__(context, backend_addr, friendly_name, concurrency)
 
         self._runtimes = {x.envtype: x for x in runtimes} if runtimes is not None else None
 

--- a/inginious/agent/mcq_agent/__init__.py
+++ b/inginious/agent/mcq_agent/__init__.py
@@ -15,15 +15,14 @@ import builtins
 
 
 class MCQAgent(Agent):
-    def __init__(self, context, backend_addr, friendly_name, concurrency, tasks_filesystem):
+    def __init__(self, context, backend_addr, friendly_name, concurrency):
         """
         :param context: ZeroMQ context for this process
         :param backend_addr: address of the backend (for example, "tcp://127.0.0.1:2222")
         :param friendly_name: a string containing a friendly name to identify agent
-        :param tasks_filesystem: FileSystemProvider to the course/tasks
         :param problem_types: Problem types dictionary
         """
-        super().__init__(context, backend_addr, friendly_name, concurrency, tasks_filesystem)
+        super().__init__(context, backend_addr, friendly_name, concurrency)
         self._logger = logging.getLogger("inginious.agent.mcq")
 
         # Init gettext

--- a/inginious/common/exceptions.py
+++ b/inginious/common/exceptions.py
@@ -5,6 +5,9 @@
 
 """ Some type of exceptions used by parts of INGInious """
 
+class NotLoadedException(Exception):
+    pass
+
 
 class InvalidNameException(Exception):
     pass

--- a/inginious/frontend/arch_helper.py
+++ b/inginious/frontend/arch_helper.py
@@ -52,11 +52,10 @@ async def _restart_on_cancel(logger, agent):
             logger.exception("Restarting agent")
             pass
 
-def create_arch(configuration, tasks_fs, context):
+def create_arch(configuration, context):
     """ Helper that can start a simple complete INGInious arch locally if needed, or a client to a remote backend.
     Intended to be used on command line, makes uses of exit() and the logger inginious.frontend.
     :param configuration: configuration dict
-    :param tasks_fs: FileSystemProvider to the courses/tasks folders
     :param context: a ZMQ context
     :param is_testing: boolean
     :return: a Client object
@@ -93,8 +92,8 @@ def create_arch(configuration, tasks_fs, context):
 
         client = Client(context, "inproc://backend_client")
         backend = Backend(context, "inproc://backend_agent", "inproc://backend_client")
-        agent_docker = DockerAgent(context, "inproc://backend_agent", "Docker - Local agent", concurrency, tasks_fs, debug_host, debug_ports, tmp_dir, ssh_allowed=True)
-        agent_mcq = MCQAgent(context, "inproc://backend_agent", "MCQ - Local agent", 1, tasks_fs)
+        agent_docker = DockerAgent(context, "inproc://backend_agent", "Docker - Local agent", concurrency, debug_host, debug_ports, tmp_dir, ssh_allowed=True)
+        agent_mcq = MCQAgent(context, "inproc://backend_agent", "MCQ - Local agent", 1)
 
         asyncio.ensure_future(_restart_on_cancel(logger, agent_docker))
         asyncio.ensure_future(_restart_on_cancel(logger, agent_mcq))

--- a/inginious/frontend/lti/__init__.py
+++ b/inginious/frontend/lti/__init__.py
@@ -16,7 +16,7 @@ from pymongo import ReturnDocument
 class LTIScorePublisher(threading.Thread, metaclass=ABCMeta):
     _submission_tags = {}
 
-    def __init__(self, mongo_collection, user_manager, fs_provider):
+    def __init__(self, mongo_collection, user_manager):
         super(LTIScorePublisher, self).__init__()
         self.daemon = True
         self._queue = queue.Queue()
@@ -24,8 +24,6 @@ class LTIScorePublisher(threading.Thread, metaclass=ABCMeta):
 
         self._mongo_collection = mongo_collection
         self._user_manager = user_manager
-        self._fs_provider = fs_provider
-
         self.start()
 
     def stop(self):

--- a/inginious/frontend/lti/v1_1/__init__.py
+++ b/inginious/frontend/lti/v1_1/__init__.py
@@ -14,9 +14,9 @@ class LTIOutcomeManager(LTIScorePublisher):
     _submission_tags = {"outcome_service_url": "outcome_service_url", "outcome_result_id": "outcome_result_id",
                         "outcome_consumer_key": "consumer_key"}
 
-    def __init__(self, database, user_manager, fs_provider):
+    def __init__(self, database, user_manager):
         self._logger = logging.getLogger("inginious.webapp.lti1_1.outcome_manager")
-        super(LTIOutcomeManager, self).__init__(database.lis_outcome_queue, user_manager, fs_provider)
+        super(LTIOutcomeManager, self).__init__(database.lis_outcome_queue, user_manager)
 
     def process(self, mongo_entry, grade):
         courseid, consumer_key, service_url, result_id = (mongo_entry["courseid"], mongo_entry["outcome_consumer_key"], mongo_entry["outcome_service_url"], mongo_entry["outcome_result_id"])
@@ -25,7 +25,7 @@ class LTIOutcomeManager(LTIScorePublisher):
             clip = lambda n, minn, maxn: min(max(n, minn), maxn)
             grade = clip(grade / 100.0, 0.0, 1.0)
 
-            course = Course.get(courseid, self._fs_provider)
+            course = Course.get(courseid)
             consumer_secret = course.lti_keys()[consumer_key]
             outcome_response = OutcomeRequest({"consumer_key": consumer_key,
                                                "consumer_secret": consumer_secret,

--- a/inginious/frontend/lti/v1_3/__init__.py
+++ b/inginious/frontend/lti/v1_3/__init__.py
@@ -43,16 +43,16 @@ class MongoLTILaunchDataStorage(LaunchDataStorage):
 class LTIGradeManager(LTIScorePublisher):
     _submission_tags = {"message_launch_id": "message_launch_id"}
 
-    def __init__(self, database, user_manager, fs_provider):
+    def __init__(self, database, user_manager):
         self._logger = logging.getLogger("inginious.webapp.lti1_3.grade_manager")
         self._database = database
-        super(LTIGradeManager, self).__init__(database.lti_grade_queue, user_manager, fs_provider)
+        super(LTIGradeManager, self).__init__(database.lti_grade_queue, user_manager)
 
     def process(self, mongo_entry, grade):
         courseid, taskid, message_launch_id = (mongo_entry["courseid"], mongo_entry["taskid"], mongo_entry["message_launch_id"])
 
         try:
-            course = Course.get(courseid, self._fs_provider)
+            course = Course.get(courseid)
             message_launch = FlaskMessageLaunch.from_cache(message_launch_id, request=None, tool_config=course.lti_tool(), launch_data_storage=MongoLTILaunchDataStorage(self._database, courseid, taskid))
             launch_data = message_launch.get_launch_data()
             ags = message_launch.get_ags()

--- a/inginious/frontend/pages/api/courses.py
+++ b/inginious/frontend/pages/api/courses.py
@@ -46,10 +46,10 @@ class APICourses(APIAuthenticatedPage):
         output = []
 
         if courseid is None:
-            courses = Course.get_all(self.fs_provider)
+            courses = Course.get_all()
         else:
             try:
-                courses = {courseid: Course.get(courseid, self.fs_provider)}
+                courses = {courseid: Course.get(courseid)}
             except:
                 raise APINotFound("Course not found")
 

--- a/inginious/frontend/pages/api/submissions.py
+++ b/inginious/frontend/pages/api/submissions.py
@@ -11,13 +11,13 @@ from inginious.frontend.courses import Course
 from inginious.frontend.pages.api._api_page import APIAuthenticatedPage, APINotFound, APIForbidden, APIInvalidArguments, APIError
 
 
-def _get_submissions(fs_provider, submission_manager, user_manager, courseid, taskid, with_input, submissionid=None):
+def _get_submissions(submission_manager, user_manager, courseid, taskid, with_input, submissionid=None):
     """
         Helper for the GET methods of the two following classes
     """
 
     try:
-        course = Course.get(courseid, fs_provider)
+        course = Course.get(courseid)
     except:
         raise APINotFound("Course not found")
 
@@ -109,7 +109,7 @@ class APISubmissionSingle(APIAuthenticatedPage):
         """
         with_input = "input" in flask.request.args
 
-        return _get_submissions(self.fs_provider, self.submission_manager, self.user_manager, courseid, taskid, with_input, submissionid)
+        return _get_submissions(self.submission_manager, self.user_manager, courseid, taskid, with_input, submissionid)
 
 
 class APISubmissions(APIAuthenticatedPage):
@@ -150,7 +150,7 @@ class APISubmissions(APIAuthenticatedPage):
         """
         with_input = "input" in flask.request.args
 
-        return _get_submissions(self.fs_provider, self.submission_manager, self.user_manager, courseid, taskid, with_input)
+        return _get_submissions(self.submission_manager, self.user_manager, courseid, taskid, with_input)
 
     def API_POST(self, courseid, taskid):  # pylint: disable=arguments-differ
         """
@@ -166,7 +166,7 @@ class APISubmissions(APIAuthenticatedPage):
         """
 
         try:
-            course = Course.get(courseid, self.fs_provider)
+            course = Course.get(courseid)
         except:
             raise APINotFound("Course not found")
 

--- a/inginious/frontend/pages/api/tasks.py
+++ b/inginious/frontend/pages/api/tasks.py
@@ -61,7 +61,7 @@ class APITasks(APIAuthenticatedPage):
         """
 
         try:
-            course = Course.get(courseid, self.fs_provider)
+            course = Course.get(courseid)
         except:
             raise APINotFound("Course not found")
 

--- a/inginious/frontend/pages/course.py
+++ b/inginious/frontend/pages/course.py
@@ -33,7 +33,7 @@ class CoursePage(INGIniousAuthPage):
     def get_course(self, courseid):
         """ Return the course """
         try:
-            course = Course.get(courseid, self.fs_provider)
+            course = Course.get(courseid)
         except:
             raise NotFound(description=_("Course not found."))
 

--- a/inginious/frontend/pages/course_admin/danger_zone.py
+++ b/inginious/frontend/pages/course_admin/danger_zone.py
@@ -56,7 +56,8 @@ class CourseDangerZonePage(INGIniousAdminPage):
 
         # Copy archive course
         archive_course_id = courseid + "_archive_" + datetime.now(tz=timezone.utc).strftime("%Y_%m_%d_%H_%M_%S")
-        self.fs_provider.copy_to(course_fs.prefix, archive_course_id)
+        archive_course_fs = Course(archive_course_id, {"name": archive_course_id}).get_fs()
+        archive_course_fs.copy_to(course_fs.prefix)
 
         # Update archive YAML file
         archive_course_content = course.get_descriptor()
@@ -64,7 +65,7 @@ class CourseDangerZonePage(INGIniousAdminPage):
         archive_course_content["archive_date"] = datetime.now(tz=timezone.utc).isoformat()
 
         # Save archived course
-        Course(archive_course_id, archive_course_content, self.fs_provider).save()
+        Course(archive_course_id, archive_course_content).save()
 
         # Update course id in DB
         self.database.submissions.update_many({"courseid": courseid}, {"$set": {"courseid": archive_course_id}})

--- a/inginious/frontend/pages/course_admin/settings.py
+++ b/inginious/frontend/pages/course_admin/settings.py
@@ -139,7 +139,7 @@ class CourseSettingsPage(INGIniousAdminPage):
 
 
         if len(errors) == 0:
-            Course(courseid, course_content, course.get_fs()).save()
+            Course(courseid, course_content).save()
             errors = None
             course, __ = self.get_course_and_check_rights(courseid, allow_all_staff=False)  # don't forget to reload the modified course
 
@@ -170,7 +170,7 @@ class CourseSettingsPage(INGIniousAdminPage):
             del tag["id"]
 
         course_content["tags"] = tags
-        Course(course.get_id(), course_content, course.get_fs()).save()
+        Course(course.get_id(), course_content).save()
         return None
 
     def prepare_datas(self, data, prefix: str):

--- a/inginious/frontend/pages/course_admin/task_edit.py
+++ b/inginious/frontend/pages/course_admin/task_edit.py
@@ -108,7 +108,7 @@ class CourseEditTask(INGIniousAdminPage):
 
         # Get the course
         try:
-            course = Course.get(courseid, self.fs_provider)
+            course = Course.get(courseid)
         except:
             return json.dumps({"status": "error", "message": _("Error while reading course's informations")})
 
@@ -121,7 +121,7 @@ class CourseEditTask(INGIniousAdminPage):
             return error
 
         try:
-            t = Task(taskid, data, course.get_fs().from_subfolder(taskid))
+            t = Task(courseid, taskid, data)
         except Exception as message:
             return json.dumps({"status": "error", "message": _("Invalid data: {}").format(str(message))})
 

--- a/inginious/frontend/pages/course_admin/utils.py
+++ b/inginious/frontend/pages/course_admin/utils.py
@@ -35,7 +35,7 @@ class INGIniousAdminPage(INGIniousAuthPage):
         """
 
         try:
-            course = Course.get(courseid, self.fs_provider)
+            course = Course.get(courseid)
             if allow_all_staff:
                 if not self.user_manager.has_staff_rights_on_course(course):
                     raise Forbidden(description=_("You don't have staff rights on this course."))

--- a/inginious/frontend/pages/course_register.py
+++ b/inginious/frontend/pages/course_register.py
@@ -17,7 +17,7 @@ class CourseRegisterPage(INGIniousAuthPage):
 
     def basic_checks(self, courseid):
         try:
-            course = Course.get(courseid, self.fs_provider)
+            course = Course.get(courseid)
         except (InvalidNameException, CourseNotFoundException, CourseUnreadableException) as e:
             raise NotFound(description=_("This course doesn't exist."))
 

--- a/inginious/frontend/pages/courselist.py
+++ b/inginious/frontend/pages/courselist.py
@@ -25,7 +25,7 @@ class CourseListPage(INGIniousPage):
         """  Display main course list page """
         username = self.user_manager.session_username()
         user_info = self.user_manager.get_user_info(username)
-        all_courses = Course.get_all(self.fs_provider)
+        all_courses = Course.get_all()
 
         # Display
         open_courses = {courseid: course for courseid, course in all_courses.items() if course.is_open_to_non_staff()}

--- a/inginious/frontend/pages/group.py
+++ b/inginious/frontend/pages/group.py
@@ -22,7 +22,7 @@ class GroupPage(INGIniousAuthPage):
     def GET_AUTH(self, courseid):  # pylint: disable=arguments-differ
         """ GET request """
 
-        course = Course.get(courseid, self.fs_provider)
+        course = Course.get(courseid)
         username = self.user_manager.session_username()
 
         error = False

--- a/inginious/frontend/pages/lti/__init__.py
+++ b/inginious/frontend/pages/lti/__init__.py
@@ -73,7 +73,7 @@ class LTIBindPage(INGIniousAuthPage):
             return error
 
         try:
-            course = Course.get(data["task"][0], self.fs_provider)
+            course = Course.get(data["task"][0])
             if data[self._field] not in self._ids_fct(course):
                 raise Exception()
         except:
@@ -120,7 +120,7 @@ class LTILoginPage(INGIniousPage):
             raise Forbidden(description=_("No LTI data available."))
 
         try:
-            course = Course.get(data["task"][0], self.fs_provider)
+            course = Course.get(data["task"][0])
             if data[self._field] not in self._ids_fct(course):
                 raise Exception()
         except:

--- a/inginious/frontend/pages/lti/v1_1/__init__.py
+++ b/inginious/frontend/pages/lti/v1_1/__init__.py
@@ -112,7 +112,7 @@ class LTI11LaunchPage(INGIniousPage):
         self.logger.debug('_parse_lti_data:' + str(post_input))
 
         try:
-            course = Course.get(courseid, self.fs_provider)
+            course = Course.get(courseid)
         except exceptions.CourseNotFoundException as ex:
             raise NotFound(description=_(str(ex)))
 

--- a/inginious/frontend/pages/lti/v1_3/__init__.py
+++ b/inginious/frontend/pages/lti/v1_3/__init__.py
@@ -22,7 +22,7 @@ class LTI13JWKSPage(INGIniousPage):
 
     def GET(self, courseid, keyset_hash):
         try:
-            course = Course.get(courseid, self.fs_provider)
+            course = Course.get(courseid)
         except exceptions.CourseNotFoundException as ex:
             raise NotFound(description=_(str(ex)))
 
@@ -42,7 +42,7 @@ class LTI13OIDCLoginPage(INGIniousPage):
     def _handle_oidc_login_request(self, courseid):
         """ Initiates the LTI 1.3 OIDC login. """
         try:
-            course = Course.get(courseid, self.fs_provider)
+            course = Course.get(courseid)
         except exceptions.CourseNotFoundException as ex:
             raise NotFound(description=_(str(ex)))
 
@@ -69,7 +69,7 @@ class LTI13LaunchPage(INGIniousPage):
     def _handle_message_launch(self, courseid, taskid):
         """ Decrypt and process the LTI Launch message. """
         try:
-            course = Course.get(courseid, self.fs_provider)
+            course = Course.get(courseid)
         except exceptions.CourseNotFoundException as ex:
             raise NotFound(description=_(str(ex)))
 

--- a/inginious/frontend/pages/marketplace.py
+++ b/inginious/frontend/pages/marketplace.py
@@ -45,7 +45,7 @@ class MarketplacePage(INGIniousAuthPage):
             new_courseid = user_input["new_courseid"]
             try:
                 course = get_marketplace_course(user_input["courseid"])
-                import_course(course, new_courseid, self.user_manager.session_username(), self.fs_provider)
+                import_course(course, new_courseid, self.user_manager.session_username())
             except ImportCourseException as e:
                 errors.append(str(e))
             except:
@@ -62,11 +62,11 @@ class MarketplacePage(INGIniousAuthPage):
         return render_template("marketplace.html", courses=courses, errors=errors)
 
 
-def import_course(course, new_courseid, username, fs_provider):
+def import_course(course, new_courseid, username):
     if not id_checker(new_courseid):
         raise ImportCourseException("Course with invalid name: " + new_courseid)
-    course_fs = fs_provider.from_subfolder(new_courseid)
 
+    course_fs = Course(new_courseid, {"name": new_courseid}).get_fs()
     if course_fs.exists("course.yaml") or course_fs.exists("course.json"):
         raise ImportCourseException("Course with id " + new_courseid + " already exists.")
 
@@ -76,7 +76,7 @@ def import_course(course, new_courseid, username, fs_provider):
         raise ImportCourseException(_("Couldn't clone course into your instance"))
 
     try:
-        old_descriptor = Course.get(new_courseid, fs_provider).get_descriptor()
+        old_descriptor = Course.get(new_courseid).get_descriptor()
     except:
         old_descriptor ={}
 
@@ -93,7 +93,7 @@ def import_course(course, new_courseid, username, fs_provider):
         new_descriptor["dispenser_data"] = {"config": {}, "toc": old_descriptor["toc"]}
 
     try:
-        Course(new_courseid, new_descriptor, course_fs).save()
+        Course(new_courseid, new_descriptor).save()
     except:
         raise ImportCourseException(_("An error occur while editing the course description"))
 

--- a/inginious/frontend/pages/marketplace_course.py
+++ b/inginious/frontend/pages/marketplace_course.py
@@ -46,7 +46,7 @@ class MarketplaceCoursePage(INGIniousAuthPage):
         if "new_courseid" in user_input:
             new_courseid = user_input["new_courseid"]
             try:
-                import_course(course, new_courseid, self.user_manager.session_username(), self.fs_provider)
+                import_course(course, new_courseid, self.user_manager.session_username())
             except ImportCourseException as e:
                 errors.append(str(e))
             if not errors:

--- a/inginious/frontend/pages/mycourses.py
+++ b/inginious/frontend/pages/mycourses.py
@@ -26,8 +26,7 @@ class MyCoursesPage(INGIniousAuthPage):
         if "new_courseid" in user_input and self.user_manager.user_is_superadmin():
             try:
                 courseid = user_input["new_courseid"]
-                course_fs = self.fs_provider.from_subfolder(courseid)
-                Course(courseid, {"name": courseid, "accessible": False}, course_fs).save()
+                Course(courseid, {"name": courseid, "accessible": False}).save()
                 success = True
             except:
                 success = False
@@ -39,7 +38,7 @@ class MyCoursesPage(INGIniousAuthPage):
         username = self.user_manager.session_username()
         user_info = self.user_manager.get_user_info(username)
 
-        all_courses = Course.get_all(self.fs_provider)
+        all_courses = Course.get_all()
 
         # Display
         open_courses = {courseid: course for courseid, course in all_courses.items()

--- a/inginious/frontend/pages/tasks.py
+++ b/inginious/frontend/pages/tasks.py
@@ -34,14 +34,13 @@ class BaseTaskPage(object):
         self.submission_manager = self.cp.submission_manager
         self.user_manager = self.cp.user_manager
         self.database = self.cp.database
-        self.fs_provider = self.cp.fs_provider
         self.default_allowed_file_extensions = self.cp.default_allowed_file_extensions
         self.default_max_file_size = self.cp.default_max_file_size
         self.webterm_link = self.cp.webterm_link
 
     def preview_allowed(self, courseid, taskid):
         try:
-            course = Course.get(courseid, self.fs_provider)
+            course = Course.get(courseid)
         except CourseNotFoundException as ex:
             raise NotFound(description=str(ex))
         return course.get_accessibility().is_open() and course.allow_preview()
@@ -52,7 +51,7 @@ class BaseTaskPage(object):
 
         # Fetch the course
         try:
-            course = Course.get(courseid, self.fs_provider)
+            course = Course.get(courseid)
         except CourseNotFoundException as ex:
             raise NotFound(description=str(ex))
 
@@ -168,7 +167,7 @@ class BaseTaskPage(object):
         """ POST a new submission """
         username = self.user_manager.session_username()
 
-        course = Course.get(courseid, self.fs_provider)
+        course = Course.get(courseid)
         if not self.user_manager.course_is_open_to_user(course, username, isLTI):
             return handle_course_unavailable(self.cp.app.get_path, self.user_manager, course)
 
@@ -414,7 +413,7 @@ class TaskPageStaticDownload(INGIniousPage):
     def GET(self, courseid, taskid, path):  # pylint: disable=arguments-differ
         """ GET request """
         try:
-            course = Course.get(courseid, self.fs_provider)
+            course = Course.get(courseid)
             if not self.user_manager.course_is_open_to_user(course):
                 return handle_course_unavailable(self.cp.app.get_path, self.user_manager, course)
 

--- a/inginious/frontend/pages/utils.py
+++ b/inginious/frontend/pages/utils.py
@@ -69,11 +69,6 @@ class INGIniousPage(MethodView):
         return self.POST(*args, **kwargs)
 
     @property
-    def fs_provider(self) -> FileSystemProvider:
-        """ Returns the filesystem provider singleton """
-        return self.app.fs_provider
-
-    @property
     def submission_manager(self) -> WebAppSubmissionManager:
         """ Returns the submission manager singleton"""
         return self.app.submission_manager

--- a/inginious/frontend/plugins/auth/facebook_auth.py
+++ b/inginious/frontend/plugins/auth/facebook_auth.py
@@ -59,7 +59,7 @@ class FacebookAuthMethod(AuthMethod):
         return '<i class="fa fa-facebook-square" style="font-size:50px; color:#4267b2;"></i>'
 
 
-def init(plugin_manager, fs_provider, client, conf):
+def init(plugin_manager, client, conf):
 
     if conf.get("debug", False):
         os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = '1'

--- a/inginious/frontend/plugins/auth/github_auth.py
+++ b/inginious/frontend/plugins/auth/github_auth.py
@@ -58,7 +58,7 @@ class GithubAuthMethod(AuthMethod):
         return '<i class="fa fa-github" style="font-size:50px; color:#24292e;"></i>'
 
 
-def init(plugin_manager, fs_provider, client, conf):
+def init(plugin_manager, client, conf):
 
     if conf.get("debug", False):
         os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = '1'

--- a/inginious/frontend/plugins/auth/google_auth.py
+++ b/inginious/frontend/plugins/auth/google_auth.py
@@ -67,7 +67,7 @@ class GoogleAuthMethod(AuthMethod):
                'user-select: none; width: 50px; height:50px;" >'
 
 
-def init(plugin_manager, fs_provider, client, conf):
+def init(plugin_manager, client, conf):
     if conf.get("debug", False):
         os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = '1'
 

--- a/inginious/frontend/plugins/auth/ldap_auth.py
+++ b/inginious/frontend/plugins/auth/ldap_auth.py
@@ -129,7 +129,7 @@ class LDAPAuthenticationPage(AuthenticationPage):
             return render_template("ldap_auth/custom_auth_form.html", settings=settings, error=_("Incorrect password"))
 
 
-def init(plugin_manager, _, _2, conf):
+def init(plugin_manager, client, conf):
     """
         Allow to connect through a LDAP service
 

--- a/inginious/frontend/plugins/auth/linkedin_auth.py
+++ b/inginious/frontend/plugins/auth/linkedin_auth.py
@@ -62,7 +62,7 @@ class LinkedInAuthMethod(AuthMethod):
         return '<i class="fa fa-linkedin-square" style="font-size:50px; color:#008CC9;"></i>'
 
 
-def init(plugin_manager, fs_provider, client, conf):
+def init(plugin_manager, client, conf):
 
     if conf.get("debug", False):
         os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = '1'

--- a/inginious/frontend/plugins/auth/saml2_auth.py
+++ b/inginious/frontend/plugins/auth/saml2_auth.py
@@ -165,7 +165,7 @@ class MetadataPage(INGIniousPage):
             raise InternalServerError(description=', '.join(errors))
 
 
-def init(plugin_manager, fs_provider, client, conf):
+def init(plugin_manager, client, conf):
     plugin_manager.add_page('/auth/<id>/metadata', MetadataPage.as_view('metadatapage_' + conf.get("id")))
     plugin_manager.register_auth_method(SAMLAuthMethod(conf.get("id"), conf.get('name', 'SAML'), conf.get('imlink', ''), conf))
 

--- a/inginious/frontend/plugins/contests/__init__.py
+++ b/inginious/frontend/plugins/contests/__init__.py
@@ -98,7 +98,7 @@ class ContestScoreboard(INGIniousAuthPage):
     """ Displays the scoreboard of the contest """
 
     def GET_AUTH(self, courseid):  # pylint: disable=arguments-differ
-        course = Course.get(courseid, self.fs_provider)
+        course = Course.get(courseid)
         task_dispenser = course.get_task_dispenser()
         if not task_dispenser.get_id() == Contest.get_id():
             raise NotFound()
@@ -197,7 +197,7 @@ class ContestAdmin(INGIniousAdminPage):
         course_content = course.get_descriptor()
         course_content["dispenser_data"]["contest_settings"] = contest_data
 
-        Course(course.get_id(), course_content, course.get_fs()).save()
+        Course(course.get_id(), course_content).save()
 
     def GET_AUTH(self, courseid):  # pylint: disable=arguments-differ
         """ GET request: simply display the form """
@@ -260,7 +260,7 @@ class ContestAdmin(INGIniousAdminPage):
             return render_template("contests/admin.html", course=course, data=contest_data, errors=errors, saved=False)
 
 
-def init(plugin_manager, fs_provider, client, config):  # pylint: disable=unused-argument
+def init(plugin_manager, client, config):  # pylint: disable=unused-argument
     """
         Init the contest plugin.
         Available configuration:

--- a/inginious/frontend/plugins/demo/__init__.py
+++ b/inginious/frontend/plugins/demo/__init__.py
@@ -15,6 +15,6 @@ class DemoPage(INGIniousPage):
         return "This is a simple demo plugin"
 
 
-def init(plugin_manager, _, _2, _3):
+def init(plugin_manager, client, config):
     """ Init the plugin """
     plugin_manager.add_page("/plugindemo", DemoPage.as_view('demopage'))

--- a/inginious/frontend/plugins/git_repo/__init__.py
+++ b/inginious/frontend/plugins/git_repo/__init__.py
@@ -94,7 +94,7 @@ class SubmissionGitSaver(threading.Thread):
         self.git.commit('-m', title)
 
 
-def init(plugin_manager, _, _2, config):
+def init(plugin_manager, client, config):
     """
         Init the plugin
 

--- a/inginious/frontend/plugins/ltibestsubmission/__init__.py
+++ b/inginious/frontend/plugins/ltibestsubmission/__init__.py
@@ -49,7 +49,7 @@ class LTI11BestSubmissionPage(INGIniousAuthPage):
         # attach the input to the submission
         best_sub = self.submission_manager.get_input_from_submission(best_sub)
 
-        task = Course.get(courseid, self.fs_provider).get_task(taskid)
+        task = Course.get(courseid).get_task(taskid)
         question_answer_list = []
         for problem in task.get_problems():
             answer = best_sub["input"][problem.get_id()]

--- a/inginious/frontend/plugins/plugin_manager.py
+++ b/inginious/frontend/plugins/plugin_manager.py
@@ -13,11 +13,7 @@ from jinja2 import  FileSystemLoader
 from inginious.frontend.user_manager import AuthMethod
 from inginious.frontend.task_problems import inspect_displayable_problem_types
 from inginious.common.tasks_problems import register_problem_types
-
-
-class PluginManagerNotLoadedException(Exception):
-    pass
-
+from inginious.common.exceptions import NotLoadedException
 
 class PluginManager(object):
     """ Registers an manage plugins. The init method inits only the Hook Manager; you have to call the method load() to start the plugins """
@@ -67,7 +63,7 @@ class PluginManager(object):
                 kwargs = out
         return kwargs
 
-    def load(self, client, flask_app, fs_provider, database, user_manager, submission_manager, config):
+    def load(self, client, flask_app, database, user_manager, submission_manager, config):
         """ Loads the plugin manager. Must be done after the initialisation of the client """
         self._flask_app = flask_app
         self._database = database
@@ -83,12 +79,12 @@ class PluginManager(object):
             register_problem_types(displayable_pbl_types)
 
             """ Initialize the module """
-            module.init(self, fs_provider, client, entry)
+            module.init(self, client, entry)
 
     def add_page(self, pattern, classname_or_viewfunc):
         """ Add a new page to the web application. Only available after that the Plugin Manager is loaded """
         if not self._loaded:
-            raise PluginManagerNotLoadedException()
+            raise NotLoadedException("PluginManager not loaded")
 
         self._flask_app.add_url_rule("/" + pattern[1:], view_func=classname_or_viewfunc)
 
@@ -98,7 +94,7 @@ class PluginManager(object):
         :param auth_method: a AuthMethod-based class
         """
         if not self._loaded:
-            raise PluginManagerNotLoadedException()
+            raise NotLoadedException("PluginManager not loaded")
         self._user_manager.register_auth_method(auth_method)
 
     def get_database(self):

--- a/inginious/frontend/plugins/scoreboard/__init__.py
+++ b/inginious/frontend/plugins/scoreboard/__init__.py
@@ -22,7 +22,7 @@ class ScoreBoardCourse(INGIniousAuthPage):
 
     def GET_AUTH(self, courseid):  # pylint: disable=arguments-differ
         """ GET request """
-        course = Course.get(courseid, self.fs_provider)
+        course = Course.get(courseid)
         scoreboards = course.get_descriptor().get('scoreboard', [])
 
         try:
@@ -50,7 +50,7 @@ class ScoreBoard(INGIniousAuthPage):
 
     def GET_AUTH(self, courseid, scoreboardid):  # pylint: disable=arguments-differ
         """ GET request """
-        course = Course.get(courseid, self.fs_provider)
+        course = Course.get(courseid)
         scoreboards = course.get_descriptor().get('scoreboard', [])
 
         try:
@@ -206,7 +206,7 @@ def task_menu(course, task):
         return None
 
 
-def init(plugin_manager, _, _2, _3):
+def init(plugin_manager, client, config):
     """
         Init the plugin.
         Available configuration in configuration.yaml:

--- a/inginious/frontend/plugins/simple_grader/__init__.py
+++ b/inginious/frontend/plugins/simple_grader/__init__.py
@@ -15,7 +15,7 @@ from inginious.client.client_sync import ClientSync
 from inginious.frontend.pages.utils import INGIniousPage
 
 
-def init(plugin_manager, fs_provider, client, config):
+def init(plugin_manager, client, config):
     """
         Init the external grader plugin. This simple grader allows only anonymous requests, and submissions are not stored in database.
 
@@ -33,7 +33,7 @@ def init(plugin_manager, fs_provider, client, config):
         Different types of request are available : see documentation
     """
     courseid = config.get('courseid', 'external')
-    course = Course.get(courseid, fs_provider)
+    course = Course.get(courseid)
     page_pattern = config.get('page_pattern', '/external')
     return_fields = re.compile(config.get('return_fields', '^(result|text|problems)$'))
 

--- a/inginious/frontend/plugins/task_editor_hook_example/__init__.py
+++ b/inginious/frontend/plugins/task_editor_hook_example/__init__.py
@@ -31,7 +31,7 @@ def on_task_editor_submit(course, taskid, task_data):
         return json.dumps({"status": "error", "message": "You must provide a task hint in Example tab 2"})
 
 
-def init(plugin_manager, fs_provider, client, config):
+def init(plugin_manager, client, config):
 
     plugin_manager.add_hook('task_editor_tab', example_task_editor_tab)
     plugin_manager.add_hook('task_editor_tab', example_task_editor_tab_2)

--- a/inginious/frontend/plugins/upcoming_tasks/__init__.py
+++ b/inginious/frontend/plugins/upcoming_tasks/__init__.py
@@ -53,7 +53,7 @@ class UpComingTasksBoard(INGIniousAuthPage):
     def page(self, time_planner):
         """ General main method called for GET and POST """
         username = self.user_manager.session_username()
-        all_courses = Course.get_all(self.fs_provider)
+        all_courses = Course.get_all()
         time_planner = self.time_planner_conversion(time_planner)
 
         # Get the courses id
@@ -118,7 +118,7 @@ class UpComingTasksBoard(INGIniousAuthPage):
                                            submissions=except_free_last_submissions)
 
 
-def init(plugin_manager, _, _2, config):
+def init(plugin_manager, client, config):
     """ Init the plugin """
     plugin_manager.add_page('/coming_tasks', UpComingTasksBoard.as_view("upcomingtasksboardpage"))
     plugin_manager.add_page('/plugins/coming_tasks/static/<path:path>', StaticMockPage.as_view("upcomingtasksstaticmockpage"))

--- a/inginious/scripts/agent_docker.py
+++ b/inginious/scripts/agent_docker.py
@@ -16,6 +16,7 @@ import sys
 from zmq.asyncio import ZMQEventLoop, Context
 import asyncio
 
+from inginious.common.filesystems import init_fs_provider
 from inginious.common.entrypoints import get_args_and_filesystem
 from inginious.agent.docker_agent import DockerAgent, DockerRuntime
 
@@ -99,6 +100,7 @@ def main():
                              "\n"
                              "Common values are 'runc docker shared' and 'kata-runtime kata root'.")
     (args, fsprovider) = get_args_and_filesystem(parser)
+    init_fs_provider(fsprovider)
 
     if not os.path.exists(args.tmpdir):
         os.makedirs(args.tmpdir)
@@ -122,7 +124,7 @@ def main():
         context = Context()
 
         # Create agent
-        agent = DockerAgent(context, args.backend, args.friendly_name, args.concurrency, fsprovider,
+        agent = DockerAgent(context, args.backend, args.friendly_name, args.concurrency,
                             address_host=args.debug_host, external_ports=args.debug_ports, tmp_dir=args.tmpdir,
                             runtimes=args.runtime, ssh_allowed=args.ssh)
 

--- a/inginious/scripts/agent_mcq.py
+++ b/inginious/scripts/agent_mcq.py
@@ -14,6 +14,7 @@ from zmq.asyncio import ZMQEventLoop, Context
 import asyncio
 
 from inginious.common.entrypoints import get_args_and_filesystem
+from inginious.common.filesystems import init_fs_provider
 from inginious.agent.mcq_agent import MCQAgent
 from inginious.common.tasks_problems import MultipleChoiceProblem, MatchProblem, register_problem_types
 
@@ -40,6 +41,7 @@ def main():
     parser.add_argument("--ptype", nargs="+", help="Python class import path for additionnal subproblem types")
 
     (args, fsprovider) = get_args_and_filesystem(parser)
+    init_fs_provider(fsprovider)
 
     # create logger
     logger = logging.getLogger("inginious")
@@ -72,7 +74,7 @@ def main():
         context = Context()
 
         # Create agent
-        agent = MCQAgent(context, args.backend, args.friendly_name, 1, fsprovider)
+        agent = MCQAgent(context, args.backend, args.friendly_name, 1)
 
         # Run!
         try:

--- a/inginious/scripts/autotest.py
+++ b/inginious/scripts/autotest.py
@@ -15,13 +15,17 @@ import sys
 
 from yaml import SafeLoader, load
 
-from inginious.common.tags import Tag
 from inginious.frontend.tasks import Task
+from inginious.frontend.task_dispensers import register_task_dispenser
 from inginious.frontend.task_dispensers.toc import TableOfContents
+from inginious.frontend.task_dispensers.combinatory_test import CombinatoryTest
 from inginious.common.log import init_logging
 from inginious.client.client_sync import ClientSync
 from inginious.frontend.arch_helper import start_asyncio_and_zmq, create_arch
+from inginious.frontend.environment_types import register_base_env_types
 from inginious.common.filesystems.local import LocalFSProvider
+from inginious.common.filesystems import init_fs_provider
+from inginious.common.tasks_problems import register_problem_types
 from inginious.frontend.task_problems import get_default_displayable_problem_types
 from inginious.frontend.parsable_text import ParsableText
 from inginious.frontend.courses import Course
@@ -36,14 +40,14 @@ def import_class(name):
     return mod
 
 
-def create_client(config, fs_provider):
+def create_client(config):
     """
     Create a new client and return it
     :param config: dict for configuration
     :return: a Client object
     """
     zmq_context, t = start_asyncio_and_zmq(config.get("debug_asyncio", False))
-    return create_arch(config, fs_provider, zmq_context)
+    return create_arch(config, zmq_context)
 
 
 def compare_all_outputs(output1, output2, keys):
@@ -129,9 +133,9 @@ def test_task(yaml_data, course, task, client, client_sync):
     :param client_sync: ClientSync object
     :return: dict whose the format is specified in compare_all_outputs function doc
     """
-    if task.get_environment() not in client.get_available_containers():
+    if task.get_environment_id() not in client.get_available_environments().get(task.get_environment_type(), ()):
         time.sleep(1)
-    if task.get_environment() not in client.get_available_containers():
+    if task.get_environment_id() not in client.get_available_environments().get(task.get_environment_type(), ()):
         raise Exception('Environment not available')
     new_output = client_sync.new_job(0, course, task, yaml_data['input'])  # request the client with input from yaml and given task
     keys = ["result", "grade", "problems", "tests", "custom", "state", "archive", "stdout", "stderr"]
@@ -139,28 +143,19 @@ def test_task(yaml_data, course, task, client, client_sync):
     return compare_all_outputs(old_output, new_output, keys)
 
 
-def test_web_task(yaml_data, course, task, config, yaml_path):
+def test_web_task(yaml_data, course, task, yaml_path):
     """
     Test the correctness of the data and task input, i.e. the content does not raise any exception and the rst contents
     are compiling
     :param yaml_data: dict, content of a task.yaml
     :param task: Task object linked to this task.yaml
-    :param config: dict, configuration values
     :param yaml_path: String, path of the file
     :return: yaml_data if any error, {} otherwise
     """
     try:
-        web_task = Task(
-            course.get_id(),
-            task.get_id(),
-            yaml_data,
-            task.get_fs(),
-            config["default_problem_types"]
-        )  # Test of init a web task with the yaml_data. if the values are incorrect, exception will be raised
+        web_task = Task(course.get_id(), task.get_id(), yaml_data)  # Test of init a web task with the yaml_data. if the values are incorrect, exception will be raised
         web_task.get_context('English').parse(debug=True)  # Test of compiling the context
-        if not Tag.check_format(web_task.get_tags()):
-            raise BaseException("Tag type not correct")
-        if web_task.get_evaluate() not in ["best", "last", "student"]:
+        if course.get_task_dispenser().get_evaluation_mode(task.get_id()) not in ["best", "last"]:
             raise BaseException("Not correct evaluation type")
         for sub_prob in yaml_data["problems"]:
             p = ParsableText(yaml_data["problems"][sub_prob]["header"])  # parse the rst of the subproblem
@@ -171,12 +166,11 @@ def test_web_task(yaml_data, course, task, config, yaml_path):
         return yaml_data
 
 
-def test_submission_yaml(client, fs_provider, path, output, client_sync):
+def test_submission_yaml(client, path, output, client_sync):
     """
     Test the content of a submission.test yaml by comparing it to the output of the client for this task and the same
     input.
     :param client: Client object
-    :param fs_provider: FileSystemProvider object
     :param path: String, path to the submission.test
     :param output: dict, output variable
     :param client_sync: ClientSync object, client_sync = ClientSync(client)
@@ -185,18 +179,17 @@ def test_submission_yaml(client, fs_provider, path, output, client_sync):
     # print(os.path.join(test_path, yaml_file.name))
     with open(path, 'r') as yaml:
         yaml_data = load(yaml, Loader=SafeLoader)
-        course = Course.get(yaml_data["courseid"], fs_provider)
+        course = Course.get(yaml_data["courseid"])
         res = test_task(yaml_data, course, course.get_task(yaml_data["taskid"]), client, client_sync)
         if res != {}:
             output[path] = res
 
 
-def test_task_yaml(path, output, fs_provider, task_name, course_name, config):
+def test_task_yaml(path, output, task_name, course_name):
     """
     Test the format and content of a task.yaml file and, if incorrect, the data is stored in the output dict
     :param path: path to the task.yaml
     :param output: output dictionary
-    :param fs_provider: FileSystemProvider object
     :param task_name: String, name of the task
     :param course_name: String, name of the course
     :param config: dict, contains configuration variable
@@ -204,19 +197,18 @@ def test_task_yaml(path, output, fs_provider, task_name, course_name, config):
     """
     with open(path, 'r') as yaml_file:
         yaml_data = load(yaml_file, Loader=SafeLoader)
-    course = Course.get(course_name, fs_provider)
-    res = test_web_task(yaml_data, course, course.get_task(task_name), config, path)
+    course = Course.get(course_name)
+    res = test_web_task(yaml_data, course, course.get_task(task_name), path)
     if res != {}:
         output[path] = res
 
 
-def test_all_files(config, client, fs_provider):
+def test_all_files(config, client):
     """
     Test each yaml file contained in the dir_path directory, with dir_path specified in the config var, as specified in
     the test_task function
     :param config: dict for configuration
     :param client: backend client of type Client
-    :param fs_provider: FilesytemProvider object
     :return: None
     """
     test_output = {}
@@ -233,9 +225,9 @@ def test_all_files(config, client, fs_provider):
                     test_files = os.scandir(test_path)
                     for yaml_file in test_files:
                         if not yaml_file.name.startswith('.') and yaml_file.is_file():  # Exclude possible failures
-                            test_submission_yaml(client, fs_provider, yaml_file.path, test_output, client_sync)
+                            test_submission_yaml(client, yaml_file.path, test_output, client_sync)
                 task_yaml_path = os.path.join(task.path, "task.yaml")
-                test_task_yaml(task_yaml_path, test_output, fs_provider, task.name, os.path.split(dir_path)[1], config)
+                test_task_yaml(task_yaml_path, test_output, task.name, os.path.split(dir_path)[1])
     if test_output != {}:  # errors in task.yaml ou submission.test
         output = json.dumps(test_output)
         if "file" in config:
@@ -260,49 +252,38 @@ def main():
     args = parser.parse_args()
 
     if args.logging:
-        # Init logging
         init_logging()
 
-    task_dispensers = {
-        task_dispenser.get_id(): task_dispenser for task_dispenser in [TableOfContents]
-    }
+    register_base_env_types()
+    init_fs_provider(LocalFSProvider(args.task_dir))
 
-    problem_types = get_default_displayable_problem_types()
+    register_task_dispenser(TableOfContents)
+    register_task_dispenser(CombinatoryTest)
+    register_problem_types(get_default_displayable_problem_types())
+
+    def load_modules(module_list, loader):
+        for module in module_list:
+            try:
+                module_class = import_class(module)
+                loader(module_class)
+            except:
+                print("Cannot load {}, exiting".format(module), file=sys.stderr)
+                exit(1)
 
     if args.tdisp:
-        for tdisp_loc in args.tdisp:
-            try:
-                tdisp = import_class(tdisp_loc)
-                task_dispensers[tdisp.get_id()] = tdisp
-            except:
-                print("Cannot load {}, exiting".format(tdisp_loc), file=sys.stderr)
-                exit(1)
+        load_modules(args.tdisp, register_task_dispenser)
 
     if args.ptype:
-        for ptype_loc in args.ptype:
-            try:
-                ptype = import_class(ptype_loc)
-                problem_types[ptype.get_type()] = ptype
-            except:
-                print("Cannot load {}, exiting".format(ptype_loc), file=sys.stderr)
-                exit(1)
+        load_modules(args.ptype, register_problem_types)
 
-    config = {
-        "task_directory": args.task_dir,
-        "course_directory": args.course_dir,
-        "backend": "local",
-        "default_problem_types": problem_types
-    }  # yaml in tests directories in each task directory
-
+    config = { "course_directory": args.course_dir, "backend": "local"}
     if args.file:
         config["file"] = args.file
 
-    fs_provider = LocalFSProvider(config["task_directory"])
-
     try:
-        client = create_client(config, fs_provider)
+        client = create_client(config)
         client.start()
-        test_all_files(config, client, fs_provider)
+        test_all_files(config, client)
     except BaseException as e:
         print("\nAn error has occured: {}\n".format(e), file=sys.stderr)
         exit(66)


### PR DESCRIPTION
This follows PR #1086 and : 
- Ensures there is only one instance FilesystemProvider using module methods. It removes the need for reference passing through all the objects used by the app.
- Update the `autotest.py` code to make it run again.

Note: it breaks the plugins `init` method by not exposing what was the `course_factory` anymore.