### PR TITLE
Make app-local redirects respect the url root

### DIFF
--- a/inginious/frontend/pages/index.py
+++ b/inginious/frontend/pages/index.py
@@ -14,11 +14,11 @@ class IndexPage(INGIniousStaticPage):
     def GET(self):  # pylint: disable=arguments-differ
         """ Display main course list page """
         if not self.app.welcome_page:
-            return redirect("/courselist")
+            return redirect(self.app.get_path("courselist"))
         return self.show_page(self.app.welcome_page)
 
     def POST(self):  # pylint: disable=arguments-differ
         """ Display main course list page """
         if not self.app.welcome_page:
-            return redirect("/courselist")
+            return redirect(self.app.get_path("courselist"))
         return self.show_page(self.app.welcome_page)

--- a/inginious/frontend/pages/preferences/bindings.py
+++ b/inginious/frontend/pages/preferences/bindings.py
@@ -36,7 +36,7 @@ class BindingsPage(INGIniousAuthPage):
                 error = True
                 msg = _("Incorrect authentication binding.")
             elif auth_binding not in user_data.bindings:
-                return redirect("/auth/signin/" + auth_binding)
+                return redirect(self.app.get_path("auth/signin/" + auth_binding))
         elif "revoke_auth_binding" in user_input:
             auth_id = user_input["revoke_auth_binding"]
             error, msg = self.user_manager.revoke_binding(self.user_manager.session_username(), auth_id)

--- a/inginious/frontend/pages/preferences/delete.py
+++ b/inginious/frontend/pages/preferences/delete.py
@@ -45,6 +45,6 @@ class DeletePage(INGIniousAuthPage):
         if "delete" in data:
             msg, error = self.delete_account(data)
             if not error:
-                return redirect("/index")
+                return redirect(self.app.get_path("index"))
 
         return render_template("preferences/delete.html", msg=msg, error=error)

--- a/inginious/frontend/pages/social.py
+++ b/inginious/frontend/pages/social.py
@@ -24,7 +24,7 @@ class AuthenticationPage(INGIniousPage):
 
     def GET(self, auth_id):
         if self.user_manager.session_is_lti():
-            return redirect("/auth/signin/" + auth_id)
+            return redirect(self.app.get_path("auth/signin/" + auth_id))
         return self.process_signin(auth_id)
 
     def POST(self, auth_id):
@@ -40,15 +40,15 @@ class CallbackPage(INGIniousPage):
         auth_storage = self.user_manager.session_auth_storage().setdefault(auth_id, {})
         user = auth_method.callback(auth_storage)
         if not user:
-            return redirect("/signin?callbackerror")
+            return redirect(self.app.get_path("signin?callbackerror"))
         if not self.user_manager.bind_user(auth_id, user):
-            return redirect("/signin?binderror")
+            return redirect(self.app.get_path("signin?binderror"))
 
         return redirect(auth_storage.get("redir_url", "/"))
 
     def GET(self, auth_id):
         if self.user_manager.session_is_lti():
-            return redirect("/auth/signin/" + auth_id)
+            return redirect(self.app.get_path("auth/signin/" + auth_id))
         return self.process_callback(auth_id)
 
     def POST(self, auth_id):

--- a/inginious/frontend/pages/utils.py
+++ b/inginious/frontend/pages/utils.py
@@ -138,7 +138,7 @@ class INGIniousAuthPage(INGIniousPage):
                                                              self.app.privacy_page is not None and
                                                              not self.user_manager.session_tos_signed())) \
                     and not self.__class__.__name__ == "ProfilePage":
-                return redirect("/preferences/profile")
+                return redirect(self.app.get_path("preferences/profile"))
 
             if not self.is_lti_page and self.user_manager.session_lti_info() is not None:  # lti session
                 self.user_manager.disconnect_user()
@@ -165,7 +165,7 @@ class INGIniousAuthPage(INGIniousPage):
         """
         if self.user_manager.session_logged_in():
             if not self.user_manager.session_username() and not self.__class__.__name__ == "ProfilePage":
-                return redirect("/preferences/profile")
+                return redirect(self.app.get_path("preferences/profile"))
 
             if not self.is_lti_page and self.user_manager.session_lti_info() is not None:  # lti session
                 self.user_manager.disconnect_user()
@@ -226,10 +226,10 @@ class INGIniousAdministratorPage(INGIniousAuthPage):
 
 class SignInPage(INGIniousAuthPage):
     def GET_AUTH(self, *args, **kwargs):
-        return redirect("/mycourses")
+        return redirect(self.app.get_path("mycourses"))
 
     def POST_AUTH(self, *args, **kwargs):
-        return redirect("/mycourses")
+        return redirect(self.app.get_path("mycourses"))
 
     def GET(self):
         return INGIniousAuthPage.GET(self)
@@ -238,11 +238,11 @@ class SignInPage(INGIniousAuthPage):
 class LogOutPage(INGIniousAuthPage):
     def GET_AUTH(self, *args, **kwargs):
         self.user_manager.disconnect_user()
-        return redirect("/courselist")
+        return redirect(self.app.get_path("courselist"))
 
     def POST_AUTH(self, *args, **kwargs):
         self.user_manager.disconnect_user()
-        return redirect("/courselist")
+        return redirect(self.app.get_path("courselist"))
 
 
 class INGIniousStaticPage(INGIniousPage):

--- a/inginious/frontend/plugins/auth/ldap_auth.py
+++ b/inginious/frontend/plugins/auth/ldap_auth.py
@@ -119,8 +119,8 @@ class LDAPAuthenticationPage(AuthenticationPage):
                 conn.unbind()
 
             if not self.user_manager.bind_user(id, (username, realname, email, {})):
-                return redirect("/signin?binderror")
-            
+                return redirect(self.app.get_path("signin?binderror"))
+
             auth_storage = self.user_manager.session_auth_storage().setdefault(id, {})
             return redirect(auth_storage.get("redir_url", "/"))
         else:


### PR DESCRIPTION
If you're hosting INGInious with a base-URL different from `/`, *e.g.,* `/inginious`,  some redirects don't respect the base URL for redirects that are meant to redirect to another page in INGInious.

For instance, the page file found at `frontend/pages/index.py` has a redirect `redirect("/courselist")`. This doesn't respect the base path (`/inginious` in our case). This means that you'll land on `/courselist` instead of `/inginious/courselist`. Our proxy thus returns a `404`.

This PR uses `get_path` to generate a base-URL respecting redirect:
https://github.com/INGInious/INGInious/blob/7591cff06832d7d9fb7eba50d7d1d59501a42a04/inginious/frontend/app.py#L102

This reflects the way redirects are handled in, e.g. https://github.com/INGInious/INGInious/blob/7591cff06832d7d9fb7eba50d7d1d59501a42a04/inginious/frontend/pages/lti/v1_3/__init__.py#L120

Example diff:

```diff
-            return redirect("/courselist")
+            return redirect(self.app.get_path("courselist"))
```

**Testing:**
I have done limited testing. The index page now redirects you correctly to `/inginious/courselist`. Otherwise, the login flow works and I can navigate the interface without trouble.  Nonetheless, I haven't done robust testing.