### PR TITLE
[task_dispensers] reset inner fields when opening task settings modal

### DIFF
--- a/inginious/frontend/templates/course_admin/task_dispensers/config_items/accessibility.html
+++ b/inginious/frontend/templates/course_admin/task_dispensers/config_items/accessibility.html
@@ -88,6 +88,7 @@
         let accessibility = dispenser_config[taskid]["accessibility"] ?? {{ config_item.default | tojson }};
         let value = 'custom';
 
+        $(this).find(".accessibility input[type='text']").val(""); // reset inner date fields
         if (accessibility === true) {
             value = 'true';
         } else if (accessibility === false) {

--- a/inginious/frontend/templates/course_admin/task_dispensers/config_items/submission_limit.html
+++ b/inginious/frontend/templates/course_admin/task_dispensers/config_items/submission_limit.html
@@ -47,6 +47,7 @@
         let sub_limit = dispenser_config[taskid]["submission_limit"] ?? {{ config_item.default | tojson  }};
         var value = 'none';
 
+        $(this).find(".submission_limits input[type='number']").val(""); // reset inner numeric fields
         if (sub_limit['amount'] > -1 && sub_limit['period'] == -1) {
             value = 'hard';
             $(this).find("#submission_limit_hard").val(sub_limit['amount']);

--- a/inginious/frontend/templates/course_admin/task_dispensers/config_items/submission_storage.html
+++ b/inginious/frontend/templates/course_admin/task_dispensers/config_items/submission_storage.html
@@ -34,6 +34,7 @@
         var no_stored_subs = dispenser_config[taskid]["no_stored_submissions"] ?? {{ config_item.default | tojson  }};
         var value = 'store_all';
 
+        $(this).find(".no_stored_submissions input[type='number']").val(""); // reset inner numeric fields
         if (no_stored_subs > 0) {
             value = 'store_not_all';
             $(this).find("#no_stored_submissions_value").val(no_stored_subs);


### PR DESCRIPTION
This compelements 4a7aa58710d544a96c77909e0c7cfac7f026a5a0 and should fix #1099. It resets the inner input fields of settings composed of a radio and inputs.

This way, it prevents the input associated with another unchecked radio to be filled with an ignored value. 4a7aa58710d544a96c77909e0c7cfac7f026a5a0 allowed to check the default value if not specified but did not empty the inner fields.