### PR TITLE
[frontend/js] refactor submission reload

### DIFF
--- a/inginious/frontend/pages/tasks.py
+++ b/inginious/frontend/pages/tasks.py
@@ -349,6 +349,10 @@ class BaseTaskPage(object):
             tojson["status"] = 'ok'
             # And also include input
             tojson["input"] = data.get_input()
+            # filter-out values for files to avoid useless traffic
+            for key, input_data in tojson["input"].items():
+                if isinstance(input_data, dict):
+                    input_data["value"] = ""
 
         if "tests" in data:
             tojson["tests"] = {}

--- a/inginious/frontend/static/js/task.js
+++ b/inginious/frontend/static/js/task.js
@@ -23,20 +23,8 @@ function init_task_page(evaluate)
     //if INGInious tells us to wait for another submission
     //this takes precedence over the link in the URL, in order to be consistent.
     if(task_form.attr("data-wait-submission")) {
-        loadOldSubmissionInput(task_form.attr("data-wait-submission"), false);
+        loadOldSubmissionInput(task_form.attr("data-wait-submission"));
         waitForSubmission(task_form.attr("data-wait-submission"));
-    }
-    else {
-        // Check if the page link contains a submission id to load, if needed
-        try {
-            // the class URLSearchParams may not exist in older browsers...
-            var loadFromURL = (new URLSearchParams(document.location.search.substring(1))).get("load");
-            if(loadFromURL !== null)
-                loadOldSubmissionInput(loadFromURL, true);
-        }
-        catch(error) {
-          console.error(error);
-        }
     }
 
     $('.submission').each(function() {
@@ -199,7 +187,8 @@ function clickOnSubmission()
 {
     if(loadingSomething)
         return;
-    loadOldSubmissionInput($(this).attr('data-submission-id'), true);
+    loadOldSubmissionInput($(this).attr('data-submission-id'));
+    waitForSubmission($(this).attr('data-submission-id'));
     $('body').removeClass('sidebar-active');
 }
 
@@ -343,73 +332,69 @@ function submitTask(with_ssh)
 //Wait for a job to end
 function waitForSubmission(submissionid)
 {
-    setTimeout(function()
-    {
-        var url = $('form#task').attr("action");
-        jQuery.post(url, {"@action": "check", "submissionid": submissionid}, null, "json")
-            .done(function(data)
+    var url = $('form#task').attr("action");
+    jQuery.post(url, {"@action": "check", "submissionid": submissionid}, null, "json")
+        .done(function(data)
+        {
+            if("status" in data && data['status'] === "waiting")
             {
-                if("status" in data && data['status'] === "waiting")
-                {
-                    waitForSubmission(submissionid);
-                    if("ssh_host" in data && "ssh_port" in data && "ssh_user" in data && "ssh_password" in data)
-                        displayRemoteDebug(submissionid, data);
-                    else
-                        displayTaskLoadingAlert(data, submissionid);
-
-                }
-                else if("status" in data && "result" in data && "grade" in data)
-                {
-                    updateMainTags(data);
-                    if("debug" in data)
-                        displayDebugInfo(data["debug"]);
-
-                    if(data['result'] == "failed")
-                        displayTaskStudentAlertWithProblems(data, "danger", false);
-                    else if(data['result'] == "success")
-                        displayTaskStudentAlertWithProblems(data, "success", false);
-                    else if(data['result'] == "timeout")
-                        displayTaskStudentAlertWithProblems(data, "warning", false);
-                    else if(data['result'] == "overflow")
-                        displayTaskStudentAlertWithProblems(data, "warning", false);
-                    else if(data['result'] == "killed")
-                        displayTaskStudentAlertWithProblems(data, "warning", false);
-                    else // == "error"
-                        displayTaskStudentAlertWithProblems(data, "danger", false);
-
-                    if("tests" in data){
-                        updateSubmission(submissionid, data['result'], data["grade"], data["tests"]);
-                    }else{
-                        updateSubmission(submissionid, data['result'], data["grade"], []);
-                    }
-                    unblurTaskForm();
-
-                    if("replace" in data && data["replace"] && $('#my_submission').length) {
-                        displayEvaluatedSubmission(submissionid, true);
-                    } else if($('#my_submission').length) {
-                        displayEvaluatedSubmission($('#my_submission').attr('data-submission-id'), false);
-                    }
-
-                    if("feedback_script" in data)
-                        eval(data["feedback_script"]);
-                }
+                if("ssh_host" in data && "ssh_port" in data && "ssh_user" in data && "ssh_password" in data)
+                    displayRemoteDebug(submissionid, data);
                 else
-                {
+                    displayTaskLoadingAlert(data, submissionid);
+                setTimeout(waitForSubmission, 1000, submissionid);
+            }
+            else if("status" in data && "result" in data && "grade" in data)
+            {
+                updateMainTags(data);
+                if("debug" in data)
+                    displayDebugInfo(data["debug"]);
+
+                if(data['result'] == "failed")
                     displayTaskStudentAlertWithProblems(data, "danger", false);
-                    updateSubmission(submissionid, "error", "0.0", []);
-                    updateTaskStatus("Failed", 0);
-                    unblurTaskForm();
+                else if(data['result'] == "success")
+                    displayTaskStudentAlertWithProblems(data, "success", false);
+                else if(data['result'] == "timeout")
+                    displayTaskStudentAlertWithProblems(data, "warning", false);
+                else if(data['result'] == "overflow")
+                    displayTaskStudentAlertWithProblems(data, "warning", false);
+                else if(data['result'] == "killed")
+                    displayTaskStudentAlertWithProblems(data, "warning", false);
+                else // == "error"
+                    displayTaskStudentAlertWithProblems(data, "danger", false);
+
+                if("tests" in data){
+                    updateSubmission(submissionid, data['result'], data["grade"], data["tests"]);
+                }else{
+                    updateSubmission(submissionid, data['result'], data["grade"], []);
+                }
+                unblurTaskForm();
+
+                if("replace" in data && data["replace"] && $('#my_submission').length) {
+                    displayEvaluatedSubmission(submissionid, true);
+                } else if($('#my_submission').length) {
+                    displayEvaluatedSubmission($('#my_submission').attr('data-submission-id'), false);
                 }
 
-            })
-            .fail(function()
+                if("feedback_script" in data)
+                    eval(data["feedback_script"]);
+            }
+            else
             {
                 displayTaskStudentAlertWithProblems(data, "danger", false);
                 updateSubmission(submissionid, "error", "0.0", []);
                 updateTaskStatus("Failed", 0);
                 unblurTaskForm();
-            });
-    }, 1000);
+            }
+
+        })
+        .fail(function()
+        {
+            displayTaskStudentAlertWithProblems(data, "danger", false);
+            updateSubmission(submissionid, "error", "0.0", []);
+            updateTaskStatus("Failed", 0);
+            unblurTaskForm();
+        });
 }
 
 //Kill a running submission
@@ -655,7 +640,7 @@ function getAlertCode(title, content, type, dismissible, additionnal_content)
 }
 
 //Load an old submission input
-function loadOldSubmissionInput(id, with_feedback)
+function loadOldSubmissionInput(id)
 {
     if(loadingSomething)
         return;
@@ -673,8 +658,6 @@ function loadOldSubmissionInput(id, with_feedback)
                 updateMainTags(data);
                 unblurTaskForm();
                 load_input(id, data['input']);
-                if(with_feedback) // load feedback in second place as it may affect the input
-                    loadOldFeedback(data);
             }
             else
             {
@@ -686,33 +669,6 @@ function loadOldSubmissionInput(id, with_feedback)
             displayTaskInputErrorAlert();
             unblurTaskForm();
         });
-}
-
-//Load feedback from an old submission
-function loadOldFeedback(data)
-{
-    if("status" in data && "result" in data)
-    {
-        if("debug" in data)
-            displayDebugInfo(data["debug"]);
-
-        if(data['result'] == "failed")
-            displayTaskStudentAlertWithProblems(data, "danger", false);
-        else if(data['result'] == "success")
-            displayTaskStudentAlertWithProblems(data, "success", false);
-        else if(data['result'] == "timeout")
-            displayTaskStudentAlertWithProblems(data, "warning", false);
-        else if(data['result'] == "overflow")
-            displayTaskStudentAlertWithProblems(data, "warning", false);
-        else if(data['result'] == "killed")
-            displayTaskStudentAlertWithProblems(data, "warning", false);
-        else // == "error"
-            displayTaskStudentAlertWithProblems(data, "danger", false);
-    }
-    else
-        displayTaskStudentAlertWithProblems($("#internalerror").text(), "danger", false);
-    if("feedback_script" in data)
-        eval(data["feedback_script"]);
 }
 
 //Load data from input into the form inputs

--- a/inginious/frontend/templates/course_admin/submission.html
+++ b/inginious/frontend/templates/course_admin/submission.html
@@ -146,7 +146,7 @@
 var problems_types = {{ pdict | safe }};
 
 $(document).ready(function() {
-    loadOldSubmissionInput("{{submission.id}}", false);
+    loadOldSubmissionInput("{{submission.id}}");
     waitForSubmission("{{submission.id}}");
 });
 </script>


### PR DESCRIPTION
This refactors the way old submissions are reloaded so that the operations are the same both at student side (task route) and admin side (submission route).

- The old URL argument `?load=<submissionid>` is removed.
- `loadOldSubmissionInput(id, with_feedback=true)` is replaced by `loadOldSubmissionInput(id)` followed by `waitForSubmission(id)`. This allows to throw duplicate code `loadOldFeedback`.
- `waitSubmission` is modified so that the first try happens immediately. This speeds up feedback reloading for one possible additional call per submission, which is neglictable.

This PR also empties the file content of file problems before returning to the user. It may slow down submission reloading drastically if uploaded files were big. Besides, they are not used when the submission is reloaded. A link is provided instead to allow the student to download them if needed. 

This last commit is not ideal because it is not agnostic of the problem structure. However, the code for downloading these files is not agnostic either. This will be refactored later in another PR.